### PR TITLE
Symlink self into third_party/src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 .PHONY: deps test build
 
 BINARY := govuk_crawler_worker
-REPO_PATH := github.com/alphagov/govuk_crawler_worker
+ORG_PATH := github.com/alphagov
+REPO_PATH := $(ORG_PATH)/govuk_crawler_worker
 
 all: deps test build
 
-deps:
+deps: third_party/src/$(REPO_PATH)
 	go run third_party.go get -t -v .
+
+third_party/src/$(REPO_PATH):
+	mkdir -p third_party/src/$(ORG_PATH)
+	ln -s ../../../.. third_party/src/$(REPO_PATH)
 
 test:
 	go run third_party.go test -v \


### PR DESCRIPTION
So that we don't clone a new copy of our own code and ignore local changes
when building/testing. This is what most of the CoreOS projects (where
third_party.go originated from) do:

https://github.com/coreos/etcd/blob/v0.4.4/build#L3-6

Should fix a problem that @rjw1 and @mattbostock experienced.

make(1) won't re-run the commands if the symlink already exists because the
target name matches the "file". However you will need to delete your
existing directory if you've already used make in the past.

---

Do you think we need to code around the directory already existing?
