### PR TITLE
[#74371458] Use HTTPS for relative links

### DIFF
--- a/crawler_message_item.go
+++ b/crawler_message_item.go
@@ -83,7 +83,7 @@ func findByElementAttribute(
 			}
 
 			if u.Host == "" && trimmedHref[0] == '/' {
-				urls = append(urls, "http://"+host+trimmedHref)
+				urls = append(urls, "https://"+host+trimmedHref)
 			}
 		}
 	})

--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -128,7 +128,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 
 			Expect(err).To(BeNil())
 			Expect(len(urls)).To(Equal(1))
-			Expect(urls).To(ContainElement("http://www.foo.com/foo/bar"))
+			Expect(urls).To(ContainElement("https://www.foo.com/foo/bar"))
 		})
 	})
 


### PR DESCRIPTION
All of GOV.UK uses HTTPS so that's what we should use to prevent
unnecessary redirects.
