### PR TITLE
Create temporary directories for tests instead of using MIRROR_ROOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: go
 go:
   - 1.2
 
-env:
-  - MIRROR_ROOT=/tmp/mirror
-
 services:
   - rabbitmq
   - redis-server

--- a/README.md
+++ b/README.md
@@ -18,12 +18,9 @@ To run this worker you will need:
 You can run the tests locally by running the following:
 
 ```bash
-export MIRROR_ROOT=${HOME}/path/to/mirror/root
 go get -v -t ./...
 go test -v ./...
 ```
-
-__Be aware that the `MIRROR_ROOT` directory will be deleted after each test runs.__
 
 Alternatively to localise the dependencies you can use `make`. This
 will use the `third_party.go` tool to vendorise dependencies into a

--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -1,7 +1,7 @@
 package main_test
 
 import (
-	"log"
+	"io/ioutil"
 
 	. "github.com/alphagov/govuk_crawler_worker"
 
@@ -16,13 +16,15 @@ import (
 var _ = Describe("CrawlerMessageItem", func() {
 	var baseUrl, expectedFilePath, host, mirrorRoot, testUrl, urlPath string
 	var delivery amqp.Delivery
+	var err error
 	var html []byte
 	var item *CrawlerMessageItem
 
 	BeforeEach(func() {
 		mirrorRoot = os.Getenv("MIRROR_ROOT")
 		if mirrorRoot == "" {
-			log.Fatal("MIRROR_ROOT environment variable not set")
+			mirrorRoot, err = ioutil.TempDir("", "crawler_message_item_test")
+			Expect(err).To(BeNil())
 		}
 
 		host = "www.gov.uk"

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -3,22 +3,18 @@ package main_test
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"time"
 
 	. "github.com/alphagov/govuk_crawler_worker"
-
 	. "github.com/alphagov/govuk_crawler_worker/http_crawler"
 	. "github.com/alphagov/govuk_crawler_worker/queue"
 	. "github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"os"
 
 	"github.com/alphagov/govuk_crawler_worker/util"
 	"github.com/fzzy/radix/redis"
@@ -33,17 +29,19 @@ var _ = Describe("Workflow", func() {
 		prefix := "govuk_mirror_crawler_workflow_test"
 
 		var (
+			err             error
+			mirrorRoot      string
 			queueManager    *QueueManager
 			queueManagerErr error
 			ttlHashSet      *TTLHashSet
 			ttlHashSetErr   error
-			mirrorRoot      string
 		)
 
 		BeforeEach(func() {
 			mirrorRoot = os.Getenv("MIRROR_ROOT")
 			if mirrorRoot == "" {
-				log.Fatal("MIRROR_ROOT environment variable not set")
+				mirrorRoot, err = ioutil.TempDir("", "workflow_test")
+				Expect(err).To(BeNil())
 			}
 
 			ttlHashSet, ttlHashSetErr = NewTTLHashSet(prefix, redisAddr)


### PR DESCRIPTION
Rather than (potentially) blowing away any directories we already have
in place when running tests and crawling against the same box, use a
temporary directory for tests.

This way, we won't trigger a deletion of a folder we want to keep and
developers no longer need to explicitly set `MIRROR_ROOT` to run the
test suite.
