### PR TITLE
Ensure that test queues/exchanges are deleted

### DIFF
--- a/queue/queue_connection_test.go
+++ b/queue/queue_connection_test.go
@@ -115,15 +115,16 @@ var _ = Describe("QueueConnection", func() {
 		})
 
 		AfterEach(func() {
+			defer consumer.Close()
+			defer publisher.Close()
+
 			deleted, err := consumer.Channel.QueueDelete(queueName, false, false, false)
 			Expect(err).To(BeNil())
 			Expect(deleted).To(Equal(0))
 
-			err = consumer.Channel.ExchangeDelete(exchangeName, false, false)
+			// Consumer cannot delete exchange unless we Cancel() or Close()
+			err = publisher.Channel.ExchangeDelete(exchangeName, false, false)
 			Expect(err).To(BeNil())
-
-			defer publisher.Close()
-			defer consumer.Close()
 		})
 
 		It("should consume and publish messages onto the provided queue and exchange", func() {

--- a/queue/queue_manager_test.go
+++ b/queue/queue_manager_test.go
@@ -61,14 +61,15 @@ var _ = Describe("QueueManager", func() {
 		})
 
 		AfterEach(func() {
+			defer queueManager.Close()
+
 			deleted, err := queueManager.Consumer.Channel.QueueDelete(queueName, false, false, false)
 			Expect(err).To(BeNil())
 			Expect(deleted).To(Equal(0))
 
-			err = queueManager.Consumer.Channel.ExchangeDelete(exchangeName, false, false)
+			// Consumer cannot delete exchange unless we Cancel() or Close()
+			err = queueManager.Producer.Channel.ExchangeDelete(exchangeName, false, false)
 			Expect(err).To(BeNil())
-
-			queueManager.Close()
 		})
 
 		It("can consume and publish to the AMQP service", func() {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -57,6 +57,8 @@ var _ = Describe("Workflow", func() {
 		})
 
 		AfterEach(func() {
+			defer queueManager.Close()
+
 			Expect(ttlHashSet.Close()).To(BeNil())
 			Expect(purgeAllKeys(prefix, redisAddr)).To(BeNil())
 
@@ -64,10 +66,10 @@ var _ = Describe("Workflow", func() {
 			Expect(err).To(BeNil())
 			Expect(deleted).To(Equal(0))
 
-			err = queueManager.Consumer.Channel.ExchangeDelete(exchangeName, false, false)
+			// Consumer cannot delete exchange unless we Cancel() or Close()
+			err = queueManager.Producer.Channel.ExchangeDelete(exchangeName, false, false)
 			Expect(err).To(BeNil())
 
-			queueManager.Close()
 			DeleteMirrorFilesFromDisk(mirrorRoot)
 		})
 


### PR DESCRIPTION
Raise errors if we're unable to delete temporary exchanges or queues in tests. This should make it more obvious when we're leaking state between tests.
