### PR TITLE
Delete compiled self from third_party/pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps test build
+.PHONY: deps test build rm_compiled_self
 
 BINARY := govuk_crawler_worker
 ORG_PATH := github.com/alphagov
@@ -6,8 +6,11 @@ REPO_PATH := $(ORG_PATH)/govuk_crawler_worker
 
 all: deps test build
 
-deps: third_party/src/$(REPO_PATH)
+deps: third_party/src/$(REPO_PATH) rm_compiled_self
 	go run third_party.go get -t -v .
+
+rm_compiled_self:
+	rm -rf third_party/pkg/*/$(REPO_PATH)
 
 third_party/src/$(REPO_PATH):
 	mkdir -p third_party/src/$(ORG_PATH)


### PR DESCRIPTION
Delete the compiled artifacts of our own package from third_party/pkg when
setting up dependencies. This will resolve errors we've seen when switching
between branches that have changed function signatures and an old compiled
copy of the function has been used.

/cc @calpaterson @KushalP 
