### PR TITLE
Move test assertions out of range(chan)

### DIFF
--- a/queue/queue_connection_test.go
+++ b/queue/queue_connection_test.go
@@ -127,7 +127,7 @@ var _ = Describe("QueueConnection", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should consume and publish messages onto the provided queue and exchange", func() {
+		It("should consume and publish messages onto the provided queue and exchange", func(done Done) {
 			err = consumer.ExchangeDeclare(exchangeName, "direct")
 			Expect(err).To(BeNil())
 
@@ -143,11 +143,10 @@ var _ = Describe("QueueConnection", func() {
 			err = publisher.Publish(exchangeName, "#", "text/plain", "foo")
 			Expect(err).To(BeNil())
 
-			for d := range deliveries {
-				Expect(string(d.Body)).To(Equal("foo"))
-				d.Ack(false)
-				break
-			}
+			item := <-deliveries
+			Expect(string(item.Body)).To(Equal("foo"))
+			item.Ack(false)
+			close(done)
 		})
 	})
 })

--- a/queue/queue_manager_test.go
+++ b/queue/queue_manager_test.go
@@ -72,18 +72,17 @@ var _ = Describe("QueueManager", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("can consume and publish to the AMQP service", func() {
+		It("can consume and publish to the AMQP service", func(done Done) {
 			deliveries, err := queueManager.Consume()
 			Expect(err).To(BeNil())
 
 			err = queueManager.Publish("#", "text/plain", "foo")
 			Expect(err).To(BeNil())
 
-			for d := range deliveries {
-				Expect(string(d.Body)).To(Equal("foo"))
-				d.Ack(false)
-				break
-			}
+			item := <-deliveries
+			Expect(string(item.Body)).To(Equal("foo"))
+			item.Ack(false)
+			close(done)
 		})
 	})
 })


### PR DESCRIPTION
This pattern of calling range on a channel and asserting that one item
matches our test assertions will fail to raise an error if the queue is
empty.

So instead change these to read a single item from the channel, which will
block if the channel is empty, and then make the assertion. I've added a
done channel so that Ginkgo fails the test if we block for longer than the
default of 1s:

http://onsi.github.io/ginkgo/#asynchronous-tests
