### PR TITLE
Build against Go 1.3 but don't fail builds if it has issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: go
 
 go:
   - 1.2
+  - 1.3
+
+matrix:
+  allow_failures:
+    - go: 1.3
+  fast_finish: true
 
 services:
   - rabbitmq


### PR DESCRIPTION
Go 1.3 has been officially released: http://blog.golang.org/go1.3

We should start building against this now to make sure that we're
keeping up-to-date with releases and to make life easier for us if we
do decide to upgrade our deployable builds to use Go 1.3.

Setting `fast_finish` to `true` so that we don't have to wait on all
components of the build matrix to complete before we get
notifications. Builds for 1.2 should be enough to trigger a status
update for the time being.
