### PR TITLE
Track the number of URLs we still have to publish

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -7,12 +7,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/etsy/statsd/examples/go"
+	"github.com/quipo/statsd"
 )
 
 var (
-	statsdClient = statsd.New("localhost", 8125)
-	statsdPrefix = "govuk_crawler_worker."
+	statsdClient = newStatsDClient("localhost:8125", "govuk_crawler_worker.")
 )
 
 func GetEnvDefault(key string, defaultVal string) string {
@@ -92,6 +91,17 @@ func (p *ProxyTCP) KillConnected() {
 }
 
 func StatsDTiming(label string, start, end time.Time) {
-	statsdClient.Timing(statsdPrefix+"time."+label,
+	statsdClient.Timing("time."+label,
 		int64(end.Sub(start)/time.Millisecond))
+}
+
+func StatsDGauge(label string, value int64) {
+	statsdClient.Gauge("gauge."+label, value)
+}
+
+func newStatsDClient(host, prefix string) *statsd.StatsdClient {
+	statsdClient := statsd.NewStatsdClient(host, prefix)
+	statsdClient.CreateSocket()
+
+	return statsdClient
 }

--- a/workflow.go
+++ b/workflow.go
@@ -181,6 +181,7 @@ func PublishURLs(ttlHashSet *ttl_hash_set.TTLHashSet, queueManager *queue.QueueM
 			}
 		}
 
+		util.StatsDGauge("publish_urls", int64(len(publish)))
 		util.StatsDTiming("publish_urls", start, time.Now())
 	}
 }


### PR DESCRIPTION
So that we can better understand one of the failure cases (early exit)
we should track the number of URLs that we haven't published back to
the exchange and that we have in progress.

Switched from the Etsy example Go code to another StatsD library
because the original Etsy code didn't support sending gauges.
