### PR TITLE
Use empty struct for signalling channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	}
 	log.Println("Generated delivery (consumer) channel:", deliveries)
 
-	dontQuit := make(chan int)
+	dontQuit := make(chan struct{})
 
 	var acknowledgeChan, crawlChan, persistChan, parseChan <-chan *CrawlerMessageItem
 	publishChan := make(<-chan string, 100)


### PR DESCRIPTION
Channels that are being used purely for signalling should use an
empty struct rather than boolean or int types.

Using an empty struct declares that we're not interested in the value
sent or received; only in its closed property.

See http://talks.golang.org/2012/10things.slide#11

Follows on from alphagov/external-link-tracker#9
