### PR TITLE
[#73135884] Increase TTL expiry time to 24 hours

### DIFF
--- a/ttl_hash_set/ttl_hash_set.go
+++ b/ttl_hash_set/ttl_hash_set.go
@@ -9,6 +9,7 @@ import (
 )
 
 const WaitBetweenReconnect = 2 * time.Second
+const ttlExpiryTime = 24 * time.Hour
 
 type ReconnectMutex struct {
 	mutex        sync.RWMutex
@@ -56,7 +57,7 @@ func (t *TTLHashSet) Add(key string) (bool, error) {
 	// Use pipelining to set the key and set expiry in one go.
 	t.mutex.Lock()
 	t.client.Append("SET", localKey, 1)
-	t.client.Append("EXPIRE", localKey, (12 * time.Hour).Seconds())
+	t.client.Append("EXPIRE", localKey, ttlExpiryTime.Seconds())
 	add, err := t.client.GetReply().Bool()
 	t.mutex.Unlock()
 


### PR DESCRIPTION
Increase the TTL expiry time because the full crawl is currently
taking just over 12 hours. As a result, we end up going round a number
of URLs again after 12 hours have passed.
