### PR TITLE
[#73135884] Log when we write URLs to disk

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -120,6 +120,7 @@ func WriteItemToDisk(basePath string, crawlChannel <-chan *CrawlerMessageItem) <
 				continue
 			}
 
+			log.Println("Wrote URL body to disk for:", item.URL())
 			extract <- item
 
 			util.StatsDTiming("write_to_disk", start, time.Now())


### PR DESCRIPTION
So that we have some audit history on where we've got to for our
crawled URLs.
