### PR TITLE
[#73135884] Increase back off time for 429 response codes

### DIFF
--- a/http_crawler/crawler_test.go
+++ b/http_crawler/crawler_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Crawl", func() {
 				testURL, _ := url.Parse(ts.URL)
 				body, err := crawler.Crawl(testURL)
 
-				Expect(err).To(Equal(RetryRequestError))
+				Expect(err).To(Equal(RetryRequest429Error))
 				Expect(body).To(Equal([]byte{}))
 			})
 
@@ -156,7 +156,7 @@ var _ = Describe("Crawl", func() {
 				testURL, _ := url.Parse(ts.URL)
 				body, err := crawler.Crawl(testURL)
 
-				Expect(err).To(Equal(RetryRequestError))
+				Expect(err).To(Equal(RetryRequest5XXError))
 				Expect(body).To(Equal([]byte{}))
 			})
 
@@ -167,7 +167,7 @@ var _ = Describe("Crawl", func() {
 				testURL, _ := url.Parse(ts.URL)
 				body, err := crawler.Crawl(testURL)
 
-				Expect(err).To(Equal(RetryRequestError))
+				Expect(err).To(Equal(RetryRequest5XXError))
 				Expect(body).To(Equal([]byte{}))
 			})
 		})
@@ -175,12 +175,11 @@ var _ = Describe("Crawl", func() {
 
 	Describe("RetryStatusCodes", func() {
 		It("should return a fixed int array with values 429, 500..599", func() {
-			statusCodes := RetryStatusCodes()
+			statusCodes := Retry5XXStatusCodes()
 
-			Expect(len(statusCodes)).To(Equal(101))
-			Expect(statusCodes[0]).To(Equal(429))
-			Expect(statusCodes[1]).To(Equal(500))
-			Expect(statusCodes[100]).To(Equal(599))
+			Expect(len(statusCodes)).To(Equal(100))
+			Expect(statusCodes[0]).To(Equal(500))
+			Expect(statusCodes[99]).To(Equal(599))
 		})
 	})
 })

--- a/workflow.go
+++ b/workflow.go
@@ -53,12 +53,14 @@ func CrawlURL(crawlChannel <-chan *CrawlerMessageItem, crawler *http_crawler.Cra
 
 			body, err := crawler.Crawl(u)
 			if err != nil {
-				if err == http_crawler.RetryRequestError {
+				if err == http_crawler.RetryRequest5XXError || err == http_crawler.RetryRequest429Error {
 					item.Reject(true)
 					log.Println("Couldn't crawl (requeueing):", u.String(), err)
 
-					// Back off from crawling for a few seconds.
-					time.Sleep(3 * time.Second)
+					if err == http_crawler.RetryRequest429Error {
+						// Back off from crawling for a few seconds.
+						time.Sleep(5 * time.Second)
+					}
 				} else {
 					item.Reject(false)
 					log.Println("Couldn't crawl (rejecting):", u.String(), err)


### PR DESCRIPTION
Increase the amount of time we back off from crawling when we receive
a 429 HTTP status code. Otherwise we won't have waited long enough for
the server to let us continue.

Also remove back off times for 5XX responses as we'll want to count
the number of times we receive a 5XX response and then manage how to
reject the message in the future.
