### PR TITLE
[#75579526] Remove #fragment when extracting URLs from the DOM

### DIFF
--- a/crawler_message_item.go
+++ b/crawler_message_item.go
@@ -99,6 +99,11 @@ func (c *CrawlerMessageItem) ExtractURLs() ([]*url.URL, error) {
 		urls = filterUrlsByHost(c.rootURL.Host, urls)
 		urls = filterBlacklistedUrls(c.blacklistPaths, urls)
 
+		// Remove the fragment from the URLs.
+		for _, u := range urls {
+			u.Fragment = ""
+		}
+
 		extractedUrls = append(extractedUrls, urls...)
 	}
 

--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -215,6 +215,15 @@ var _ = Describe("CrawlerMessageItem", func() {
 			Expect(len(urls)).To(Equal(1))
 			Expect(urls).To(ContainElement(expectedUrl))
 		})
+
+		It("should remove the #fragment when extracting URLs", func() {
+			item.HTMLBody = []byte(`<div><a href="http://www.gov.uk/#germany"></a></div>`)
+			expectedUrl, _ := url.Parse("http://www.gov.uk/")
+			urls, err := item.ExtractURLs()
+
+			Expect(err).To(BeNil())
+			Expect(urls).To(ContainElement(expectedUrl))
+		})
 	})
 
 	It("removes paths that are blacklisted", func() {


### PR DESCRIPTION
This change strips the #fragment part of the URL when extracting URLs.
It fixes a bug where we were crawling the same URL multiple times, but
with different fragment identifiers.

Rather than crawling both `gov.uk/` and `gov.uk/#foo`, we'd now only
crawl the former case.
