### PR TITLE
Continue to next URL if URL invalid

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -48,6 +48,7 @@ func CrawlURL(crawlChannel <-chan *CrawlerMessageItem, crawler *http_crawler.Cra
 			if err != nil {
 				item.Reject(false)
 				log.Println("Couldn't crawl, invalid URL (rejecting):", item.URL(), err)
+				continue
 			}
 			log.Println("Crawling URL:", u)
 


### PR DESCRIPTION
We should skip to the next item when we encounter an invalid URL.
