### PR TITLE
Increase cache timeout to 48 hours

### DIFF
--- a/ttl_hash_set/ttl_hash_set.go
+++ b/ttl_hash_set/ttl_hash_set.go
@@ -9,7 +9,7 @@ import (
 )
 
 const WaitBetweenReconnect = 2 * time.Second
-const ttlExpiryTime = 24 * time.Hour
+const ttlExpiryTime = 48 * time.Hour
 
 type ReconnectMutex struct {
 	mutex        sync.RWMutex


### PR DESCRIPTION
Whilst we're testing we're not so worried about pages falling out of
cache. This way we can continually load up messages into the message
queue and the keys will still be cached over two days.
