### PR TITLE
Log when we're sleeping a goroutine for a 429 response

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -63,8 +63,11 @@ func CrawlURL(crawlChannel <-chan *CrawlerMessageItem, crawler *http_crawler.Cra
 					log.Println("Couldn't crawl (requeueing):", u.String(), err)
 
 					if err == http_crawler.RetryRequest429Error {
+						sleepTime := 5 * time.Second
+
 						// Back off from crawling for a few seconds.
-						time.Sleep(5 * time.Second)
+						log.Println("Sleeping for: ", sleepTime, " seconds. Received 429 HTTP status")
+						time.Sleep(sleepTime)
 					}
 				} else {
 					item.Reject(false)


### PR DESCRIPTION
When we're told we're making too many requests, and we're sleeping we
should log this action so a user watching the process can better
understand what's going on.
