### PR TITLE
Continue when we reject a message for not extracting URLs

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -158,6 +158,8 @@ func ExtractURLs(extractChannel <-chan *CrawlerMessageItem) (<-chan string, <-ch
 			if err != nil {
 				item.Reject(false)
 				log.Println("ExtractURLs (rejecting):", string(item.Body), err)
+
+				continue
 			}
 
 			log.Println("Extracted URLs:", len(urls))


### PR DESCRIPTION
We can't do both rejection and acknowledgement of a message. So if we
reject a message, we should continue to the next one.
