### PR TITLE
Show Travis badge only for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOV.UK Crawler Worker
 
-[![continuous integration status](https://secure.travis-ci.org/alphagov/govuk_crawler_worker.png)](http://travis-ci.org/alphagov/govuk_crawler_worker)
+[![continuous integration status](https://travis-ci.org/alphagov/govuk_crawler_worker.svg?branch=master)](http://travis-ci.org/alphagov/govuk_crawler_worker)
 
 This is a worker that will consume [GOV.UK](https://www.gov.uk/) URLs
 from a message queue and crawl them, saving the output to disk.


### PR DESCRIPTION
The Travis build badge was showing as 'failing' because it represented
all branches, some of which were failing.

Change it so that it only represents the master branch, which is what we
care about.
