### PR TITLE
[#76062972] Reduce reliance on `time.Sleep` for tests

### DIFF
--- a/ttl_hash_set/ttl_hash_set_test.go
+++ b/ttl_hash_set/ttl_hash_set_test.go
@@ -62,11 +62,9 @@ var _ = Describe("TTLHashSet", func() {
 			Expect(err.Error()).To(MatchRegexp("EOF|connection reset by peer"))
 			Expect(exists).To(Equal(false))
 
-			time.Sleep(delayBetween) // Allow other goroutine to reconnect.
-			exists, err = ttlHashSet.Exists(key)
-
-			Expect(err).To(BeNil())
-			Expect(exists).To(Equal(true))
+			Eventually(func() (bool, error) {
+				return ttlHashSet.Exists(key)
+			}).Should(Equal(true))
 		})
 
 		It("should return errors until reconnected", func() {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"time"
 
 	. "github.com/alphagov/govuk_crawler_worker"
 	. "github.com/alphagov/govuk_crawler_worker/http_crawler"
@@ -102,9 +101,8 @@ var _ = Describe("Workflow", func() {
 				Expect(len(outbound)).To(Equal(1))
 
 				go AcknowledgeItem(outbound, ttlHashSet)
-				time.Sleep(time.Millisecond)
 
-				Expect(len(outbound)).To(Equal(0))
+				Eventually(outbound).Should(HaveLen(0))
 
 				exists, err = ttlHashSet.Exists(url)
 				Expect(err).To(BeNil())
@@ -225,13 +223,12 @@ var _ = Describe("Workflow", func() {
 					}
 				}()
 				go PublishURLs(ttlHashSet, queueManager, publish)
-				time.Sleep(time.Millisecond)
 
 				publish <- url
-				time.Sleep(time.Millisecond)
+				Expect(len(publish)).To(Equal(1))
 
-				Expect(len(publish)).To(Equal(0))
-				Expect(len(outbound)).To(Equal(0))
+				Eventually(publish).Should(HaveLen(0))
+				Eventually(outbound).Should(HaveLen(0))
 
 				// Close the channel to stop the goroutine for PublishURLs.
 				close(publish)


### PR DESCRIPTION
Where possible we should use the asynchronous constructs provided by
our testing utilities (ginkgo and gomega).

The majority of tests have been converted to use these new matchers.
The only test that hasn't been converted is one that relies on
timings (TCP reconnection in Redis) where an internal goroutine's
behaviour (read: delay) is time-based.
