### PR TITLE
If the `notifyClose` channel is closed we should exit early

### DIFF
--- a/queue/queue_connection.go
+++ b/queue/queue_connection.go
@@ -39,9 +39,15 @@ func NewQueueConnection(amqpURI string) (*QueueConnection, error) {
 
 	go func() {
 		select {
-		case e := <-queueConnection.notifyClose:
+		case e, ok := <-queueConnection.notifyClose:
 			if e != nil && !e.Recover {
 				queueConnection.HandleFatalError(e)
+			}
+
+			if !ok {
+				queueConnection.Channel.Close()
+				queueConnection.Connection.Close()
+				queueConnection.notifyClose = nil
 			}
 		}
 	}()


### PR DESCRIPTION
During channel (and connection) shutdown, the AMQP library we're using
here closes the various notification channels we provide it on
instantiation.

If we don't check whether or not the notification channel for
`notifyClose` is open then we won't ever know whether a higher up
method closes it.

By adding a condition for this we can know if a process higher up has
closed the channel.

Also wrapped the select in a `for` loop so that it is continually
evaluated rather than only operating on a single read from the
`notifyClose` channel.
