### PR TITLE
Log when the AMQP channel's `notifyClose` channel is closed

### DIFF
--- a/health_check_test.go
+++ b/health_check_test.go
@@ -34,6 +34,9 @@ var _ = Describe("HealthCheck", func() {
 			amqpAddr, exchangeName, queueName)
 		Expect(queueManagerErr).To(BeNil())
 
+		queueManager.Consumer.HandleChannelClose = func(_ string) {}
+		queueManager.Producer.HandleChannelClose = func(_ string) {}
+
 		ttlHashSet, ttlHashSetErr := ttl_hash_set.NewTTLHashSet(prefix, redisAddr)
 		Expect(ttlHashSetErr).To(BeNil())
 
@@ -60,6 +63,9 @@ var _ = Describe("HealthCheck", func() {
 			queueManager, queueManagerErr = queue.NewQueueManager(
 				amqpAddr, exchangeName, queueName)
 			Expect(queueManagerErr).To(BeNil())
+
+			queueManager.Consumer.HandleChannelClose = func(_ string) {}
+			queueManager.Producer.HandleChannelClose = func(_ string) {}
 
 			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr)
 			Expect(ttlHashSetErr).To(BeNil())
@@ -104,6 +110,9 @@ var _ = Describe("HealthCheck", func() {
 			queueManager, queueManagerErr = queue.NewQueueManager(
 				amqpAddr, exchangeName, queueName)
 			Expect(queueManagerErr).To(BeNil())
+
+			queueManager.Consumer.HandleChannelClose = func(_ string) {}
+			queueManager.Producer.HandleChannelClose = func(_ string) {}
 
 			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr)
 			Expect(ttlHashSetErr).To(BeNil())

--- a/queue/queue_connection_test.go
+++ b/queue/queue_connection_test.go
@@ -49,6 +49,8 @@ var _ = Describe("QueueConnection", func() {
 				fatalErrs <- err
 			}
 
+			connection.HandleChannelClose = func(_ string) {}
+
 			_, err = connection.QueueDeclare(queueName)
 			Expect(err).To(BeNil())
 		})
@@ -98,6 +100,7 @@ var _ = Describe("QueueConnection", func() {
 
 		BeforeEach(func() {
 			connection, connectionErr = NewQueueConnection(amqpAddr)
+			connection.HandleChannelClose = func(_ string) {}
 		})
 
 		AfterEach(func() {
@@ -182,6 +185,9 @@ var _ = Describe("QueueConnection", func() {
 			consumer, err = NewQueueConnection(amqpAddr)
 			Expect(err).To(BeNil())
 			Expect(consumer).ToNot(BeNil())
+
+			publisher.HandleChannelClose = func(_ string) {}
+			consumer.HandleChannelClose = func(_ string) {}
 		})
 
 		AfterEach(func() {

--- a/queue/queue_manager_test.go
+++ b/queue/queue_manager_test.go
@@ -29,6 +29,9 @@ var _ = Describe("QueueManager", func() {
 			exchangeName,
 			queueName)
 
+		queueManager.Consumer.HandleChannelClose = func(_ string) {}
+		queueManager.Producer.HandleChannelClose = func(_ string) {}
+
 		Expect(err).To(BeNil())
 		Expect(queueManager).ToNot(BeNil())
 
@@ -58,6 +61,9 @@ var _ = Describe("QueueManager", func() {
 
 			Expect(queueManagerErr).To(BeNil())
 			Expect(queueManager).ToNot(BeNil())
+
+			queueManager.Consumer.HandleChannelClose = func(_ string) {}
+			queueManager.Producer.HandleChannelClose = func(_ string) {}
 		})
 
 		AfterEach(func() {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -57,6 +57,9 @@ var _ = Describe("Workflow", func() {
 
 			Expect(queueManagerErr).To(BeNil())
 			Expect(queueManager).ToNot(BeNil())
+
+			queueManager.Consumer.HandleChannelClose = func(_ string) {}
+			queueManager.Producer.HandleChannelClose = func(_ string) {}
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
We didn't have anything to check whether the `notifyClose` channel was
open. We were only doing something when an `amqp.Error` message was
added to the channel.

By adding this, we'll be able to track when/why a channel might be
closed.
