### PR TITLE
[#76261684] Log acknowledgement errors and increase reader channel buffer

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func main() {
 		crawlerThreadsInt = 1
 	}
 
-	crawlChan = ReadFromQueue(deliveries, rootURL, ttlHashSet, splitPaths(blacklistPaths))
+	crawlChan = ReadFromQueue(deliveries, rootURL, ttlHashSet, splitPaths(blacklistPaths), crawlerThreadsInt)
 	persistChan = CrawlURL(crawlChan, crawler, crawlerThreadsInt)
 	parseChan = WriteItemToDisk(mirrorRoot, persistChan)
 	publishChan, acknowledgeChan = ExtractURLs(parseChan)

--- a/workflow.go
+++ b/workflow.go
@@ -15,8 +15,14 @@ import (
 	"github.com/streadway/amqp"
 )
 
-func ReadFromQueue(inboundChannel <-chan amqp.Delivery, rootURL *url.URL, ttlHashSet *ttl_hash_set.TTLHashSet, blacklistPaths []string) chan *CrawlerMessageItem {
-	outboundChannel := make(chan *CrawlerMessageItem, 2)
+func ReadFromQueue(
+	inboundChannel <-chan amqp.Delivery,
+	rootURL *url.URL,
+	ttlHashSet *ttl_hash_set.TTLHashSet,
+	blacklistPaths []string,
+	crawlerThreads int,
+) chan *CrawlerMessageItem {
+	outboundChannel := make(chan *CrawlerMessageItem, crawlerThreads)
 
 	readLoop := func(
 		inbound <-chan amqp.Delivery,

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -271,7 +271,7 @@ var _ = Describe("Workflow", func() {
 				deliveries, err := queueManager.Consume()
 				Expect(err).To(BeNil())
 
-				outbound := ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{})
+				outbound := ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
 				Expect(len(outbound)).To(Equal(0))
 
 				url := "https://www.gov.uk/bar"


### PR DESCRIPTION
The biggest change here is that we're now logging when we receive an error from acknowledging an item from the queue:

``` go
if err = item.Ack(false); err != nil {
    log.Println("Ack failed (ReadFromQueue): ", string(item.Body))
}
```

The other part of the change is to configure the channel buffer that we're using to hold messages from the queue and to increase it to equal the number of crawler goroutines we hold at a time.
