### PR TITLE
Reject item only after sleeping or retry increment

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -115,9 +115,6 @@ func CrawlURL(
 			body, err := crawler.Crawl(u)
 			if err != nil {
 				if err == http_crawler.RetryRequest5XXError || err == http_crawler.RetryRequest429Error {
-					item.Reject(true)
-					log.Println("Couldn't crawl (requeueing):", u.String(), err)
-
 					if err == http_crawler.RetryRequest5XXError {
 						ttlHashSet.Incr(u.String())
 					} else if err == http_crawler.RetryRequest429Error {
@@ -127,6 +124,9 @@ func CrawlURL(
 						log.Println("Sleeping for: ", sleepTime, " seconds. Received 429 HTTP status")
 						time.Sleep(sleepTime)
 					}
+
+					item.Reject(true)
+					log.Println("Couldn't crawl (requeueing):", u.String(), err)
 				} else {
 					item.Reject(false)
 					log.Println("Couldn't crawl (rejecting):", u.String(), err)


### PR DESCRIPTION
Prevent two race conditions by moving the rejection (and requeueing) of
the RabbitMQ message until after we have incremented the number of
retries against that URL or have slept on encountering a HTTP 429.

The race conditions that this solves are:
- The case where a HTTP 5XX error is encountered, the message would
  have been requeued and potentially read by `ReadFromQueue()` before
  the retry count was incremented on `*TTLHashSet` meaning we might
  retry a URL more than the desired maximum number of retries.
- The case where a HTTP 429 error is encountered, the message would
  have been requeued and the URL hit again by another goroutine
  _before_ the `time.Sleep()`.
