### PR TITLE
Prefix all test exchange and queue names

### DIFF
--- a/health_check_test.go
+++ b/health_check_test.go
@@ -25,7 +25,8 @@ var _ = Describe("HealthCheck", func() {
 
 	BeforeEach(func() {
 		amqpAddr = util.GetEnvDefault("AMQP_ADDRESS", "amqp://guest:guest@localhost:5672/")
-		exchangeName, queueName = "test-health-check-exchange", "test-health-check-queue"
+		exchangeName = "govuk_crawler_worker-test-health-check-exchange"
+		queueName = "govuk_crawler_worker-test-health-check-queue"
 		redisAddr = util.GetEnvDefault("REDIS_ADDRESS", "127.0.0.1:6379")
 		prefix = "govuk_mirror_crawler_health_check_test"
 	})

--- a/queue/queue_connection_test.go
+++ b/queue/queue_connection_test.go
@@ -27,7 +27,7 @@ var _ = Describe("QueueConnection", func() {
 			connection *QueueConnection
 			proxy      *util.ProxyTCP
 			proxyAddr  string           = "localhost:5673"
-			queueName  string           = "test-crawler-queue"
+			queueName  string           = "govuk_crawler_worker-test-crawler-queue"
 			fatalErrs  chan *amqp.Error = make(chan *amqp.Error)
 		)
 
@@ -118,7 +118,7 @@ var _ = Describe("QueueConnection", func() {
 
 		It("can declare an exchange", func() {
 			var err error
-			exchange := "some-exchange"
+			exchange := "govuk_crawler_worker-some-exchange"
 
 			err = connection.ExchangeDeclare(exchange, "direct")
 			Expect(err).To(BeNil())
@@ -131,7 +131,7 @@ var _ = Describe("QueueConnection", func() {
 			var (
 				err   error
 				queue amqp.Queue
-				name  = "some-queue"
+				name  = "govuk_crawler_worker-some-queue"
 			)
 
 			queue, err = connection.QueueDeclare(name)
@@ -146,8 +146,8 @@ var _ = Describe("QueueConnection", func() {
 		It("can bind a queue to an exchange", func() {
 			var err error
 
-			exchangeName := "some-binding-exchange"
-			queueName := "some-binding-queue"
+			exchangeName := "govuk_crawler_worker-some-binding-exchange"
+			queueName := "govuk_crawler_worker-some-binding-queue"
 
 			err = connection.ExchangeDeclare(exchangeName, "direct")
 			Expect(err).To(BeNil())
@@ -174,8 +174,8 @@ var _ = Describe("QueueConnection", func() {
 			err       error
 		)
 
-		exchangeName := "test-crawler-exchange"
-		queueName := "test-crawler-queue"
+		exchangeName := "govuk_crawler_worker-test-crawler-exchange"
+		queueName := "govuk_crawler_worker-test-crawler-queue"
 
 		BeforeEach(func() {
 			publisher, err = NewQueueConnection(amqpAddr)

--- a/queue/queue_manager_test.go
+++ b/queue/queue_manager_test.go
@@ -23,7 +23,9 @@ var _ = Describe("QueueManager", func() {
 	})
 
 	It("provides a way of closing connections cleanly", func() {
-		exchangeName, queueName := "test-manager-exchange", "test-manager-queue"
+		exchangeName := "govuk_crawler_worker-test-manager-exchange"
+		queueName := "govuk_crawler_worker-test-manager-queue"
+
 		queueManager, err := NewQueueManager(
 			amqpAddr,
 			exchangeName,
@@ -51,7 +53,8 @@ var _ = Describe("QueueManager", func() {
 			queueManagerErr error
 		)
 
-		exchangeName, queueName := "test-handler-exchange", "test-handler-queue"
+		exchangeName := "govuk_crawler_worker-test-handler-exchange"
+		queueName := "govuk_crawler_worker-test-handler-queue"
 
 		BeforeEach(func() {
 			queueManager, queueManagerErr = NewQueueManager(

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -24,7 +24,8 @@ var _ = Describe("Workflow", func() {
 	Describe("Acknowledging items", func() {
 		amqpAddr := util.GetEnvDefault("AMQP_ADDRESS", "amqp://guest:guest@localhost:5672/")
 		redisAddr := util.GetEnvDefault("REDIS_ADDRESS", "127.0.0.1:6379")
-		exchangeName, queueName := "test-workflow-exchange", "test-workflow-queue"
+		exchangeName := "govuk_crawler_worker-test-workflow-exchange"
+		queueName := "govuk_crawler_worker-test-workflow-queue"
 		prefix := "govuk_mirror_crawler_workflow_test"
 
 		var (


### PR DESCRIPTION
So that they match the permissions in alphagov/ci-puppet#197 and that it's
clear who these resources belong to in a shared environment like CI.

---

This and the other PR are required to get the tests passing in CI again and deploy to preview.
