### PR TITLE
[#76505094] Add non-HTML URLs to the TTLHashSet

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -143,6 +143,11 @@ func CrawlURL(
 				if err = item.Ack(false); err != nil {
 					log.Println("Ack failed (CrawlURL): ", item.URL())
 				}
+
+				err = ttlHashSet.Set(item.URL(), AlreadyCrawled)
+				if err != nil {
+					log.Println("Couldn't mark item as already crawled:", item.URL(), err)
+				}
 			}
 
 			util.StatsDTiming("crawl_url", start, time.Now())

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -176,6 +176,39 @@ var _ = Describe("Workflow", func() {
 				close(crawlChan)
 			})
 
+			It("adds a non-HTML URL to the TTLHashSet so we don't immediately retry it", func() {
+				body := `I am not HTML. No HTML, see?`
+				server := testServer(http.StatusOK, body)
+
+				deliveries, err := queueManager.Consume()
+				Expect(err).To(BeNil())
+
+				crawlChan := ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
+				Expect(len(crawlChan)).To(Equal(0))
+
+				maxRetries := 4
+
+				err = queueManager.Publish("#", "text/plain", server.URL)
+				Expect(err).To(BeNil())
+				Eventually(crawlChan).Should(HaveLen(1))
+
+				crawled := CrawlURL(ttlHashSet, crawlChan, crawler, 1, maxRetries)
+				Eventually(crawlChan).Should(HaveLen(0))
+
+				Eventually(func() (int, error) {
+					return ttlHashSet.Get(server.URL)
+				}).Should(Equal(AlreadyCrawled))
+
+				Eventually(func() (int, error) {
+					queueInfo, err := queueManager.Producer.Channel.QueueInspect(queueManager.QueueName)
+					return queueInfo.Messages, err
+				}).Should(Equal(0))
+				Expect(len(crawled)).To(Equal(0))
+
+				server.Close()
+				close(crawlChan)
+			})
+
 			It("expects the number of goroutines to run to be a positive integer", func() {
 				outbound := make(chan *CrawlerMessageItem, 1)
 


### PR DESCRIPTION
To prevent us from retrying non-HTML URLs each time we encounter them,
ensure that they are marked in the TTLHashSet (backed by Redis) as
'already crawled', meaning they won't be retried for as a long as the
TTLHashSet's expiry time (currently 48 hours).
