### PR TITLE
[#76585878] Keep errors separate

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -135,8 +135,7 @@ func CrawlURL(
 						log.Errorln("Couldn't mark item as already crawled:", u.String(), setErr)
 					}
 
-					item.Reject(false)
-					log.Warningln("Couldn't crawl (rejecting):", u.String(), err)
+					fallthrough
 				default:
 					item.Reject(false)
 					log.Warningln("Couldn't crawl (rejecting):", u.String(), err)


### PR DESCRIPTION
The `nil` value returned by `*TTLHashSet.Set` as an `error` type was
overwriting the `err` variable that stores the error returned by
`CrawlURL()`, which led to a nil errors being logged such as:

```
WARN[0000] Couldn't crawl (rejecting): http://127.0.0.1:51892 <nil>
```

This also means we can use the `fallthrough` keyword to reduce duplication.
