### PR TITLE
Calling `ExtractURLs()` only returns unique URLs

### DIFF
--- a/crawler_message_item.go
+++ b/crawler_message_item.go
@@ -104,6 +104,8 @@ func (c *CrawlerMessageItem) ExtractURLs() ([]*url.URL, error) {
 		extractedURLs = append(extractedURLs, urls...)
 	}
 
+	extractedURLs = filterDuplicateURLs(extractedURLs)
+
 	return extractedURLs, err
 }
 
@@ -154,6 +156,20 @@ func filterBlacklistedURLs(blacklistedPaths []string, urls []*url.URL) []*url.UR
 	return filterURLs(urls, func(url *url.URL) bool {
 		return !isBlacklistedPath(url.Path, blacklistedPaths)
 	})
+}
+
+func filterDuplicateURLs(urls []*url.URL) []*url.URL {
+	urlMap := make(map[string]*url.URL)
+	for _, url := range urls {
+		urlMap[url.String()] = url
+	}
+
+	uniqueUrls := make([]*url.URL, 0, len(urlMap))
+	for _, url := range urlMap {
+		uniqueUrls = append(uniqueUrls, url)
+	}
+
+	return uniqueUrls
 }
 
 // Filter an array of *url.URL objects based on a filter function that

--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -276,5 +276,13 @@ var _ = Describe("CrawlerMessageItem", func() {
 			Expect(err).To(BeNil())
 			Expect(len(urls)).To(Equal(1))
 		})
+
+		It("should only return unique URLs", func() {
+			item.HTMLBody = []byte(`<a href="http://www.gov.uk/foo">a</a><a href="http://www.gov.uk/foo">b</a>`)
+			urls, err := item.ExtractURLs()
+
+			Expect(err).To(BeNil())
+			Expect(urls).To(HaveLen(1))
+		})
 	})
 })


### PR DESCRIPTION
Many pages on GOV.UK link to the same page multiple times. To prevent
the same URLs being added to the queue, we should make sure that the
set of URLs we extract is unique.

Had to use a `map[string]*url.URL` here and iterate through the keys
because Go doesn't have an in-built Set data structure. Just arrays
and maps.
