### PR TITLE
Log redirect 'errors' at INFO level

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -135,7 +135,9 @@ func CrawlURL(
 						log.Errorln("Couldn't mark item as already crawled:", u.String(), setErr)
 					}
 
-					fallthrough
+					item.Reject(false)
+					// log at INFO because redirect URLs are not a concern
+					log.Infoln("Couldn't crawl (rejecting):", u.String(), err)
 				default:
 					item.Reject(false)
 					log.Warningln("Couldn't crawl (rejecting):", u.String(), err)


### PR DESCRIPTION
Downgrade the log level when we encounter a URL that returns a HTTP
redirect status code to `INFO` level, which will prevent it from
appearing in our logs.

We have many redirect URLs and they are not a cause for concern.
