### PR TITLE
Use an alphagov fork of the redis library

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,7 +4,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/fzzy/radix/redis"
+	// FIXME: Use the parent library once #35 has been fixed here:
+	// https://github.com/fzzy/radix/issues/35
+	"github.com/alphagov/radix/redis"
 )
 
 func DeleteMirrorFilesFromDisk(mirrorRoot string) {

--- a/ttl_hash_set/ttl_hash_set.go
+++ b/ttl_hash_set/ttl_hash_set.go
@@ -5,7 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fzzy/radix/redis"
+	// FIXME: Use the parent library once #35 has been fixed here:
+	// https://github.com/fzzy/radix/issues/35
+	"github.com/alphagov/radix/redis"
 )
 
 const WaitBetweenReconnect = 2 * time.Second

--- a/ttl_hash_set/ttl_hash_set_test.go
+++ b/ttl_hash_set/ttl_hash_set_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/alphagov/govuk_crawler_worker/util"
-	"github.com/fzzy/radix/redis"
+	// FIXME: Use the parent library once #35 has been fixed here:
+	// https://github.com/fzzy/radix/issues/35
+	"github.com/alphagov/radix/redis"
 )
 
 var _ = Describe("TTLHashSet", func() {


### PR DESCRIPTION
In the last 24 hours a bug was added to the Redis library that we're
using. The bug has been tracked[1] and a small test case[2] has been
written to reproduce it.

In the mean time, we're going to use a fork of the radix Redis library
that we pin the version for instead of directly checking the library
into a `third_party` directory using `third_party.go`.

This was discussed with @bradleywright as the right thing to do short
term until we can get around to fixing the library in question.

[1] https://github.com/fzzy/radix/issues/35
[2]
https://github.com/KushalP/radix/compare/try-to-reproduce-bug-as-tests-added-in-35

P.S. We still haven't defined a consistent way of managing
dependencies across alphagov projects that have been written in Go.
This was deemed a good enough solution to unblock us for now.
