### PR TITLE
Log to stderr rather than stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func init() {
 		log.SetLevel(log.WarnLevel)
 	}
 
-	log.SetOutput(os.Stdout)
+	log.SetOutput(os.Stderr)
 
 	if *versionFlag {
 		fmt.Println(versionNumber)


### PR DESCRIPTION
We don't collect application logs on stdout using logstash, just on
stderr.
