### PR TITLE
Change a raw `Expect` test to poll asynchronously with `Eventually`

### DIFF
--- a/workflow_test.go
+++ b/workflow_test.go
@@ -107,10 +107,10 @@ var _ = Describe("Workflow", func() {
 				go AcknowledgeItem(outbound, ttlHashSet)
 
 				Eventually(outbound).Should(HaveLen(0))
-
-				exists, err = ttlHashSet.Exists(url)
-				Expect(err).To(BeNil())
-				Expect(exists).To(Equal(true))
+				Eventually(func() bool {
+					exists, _ := ttlHashSet.Exists(url)
+					return exists
+				}).Should(BeTrue())
 
 				// Close the channel to stop the goroutine for AcknowledgeItem.
 				close(outbound)


### PR DESCRIPTION
This test is flaky as it's only called once to check the value. It
needs to be polled over time as it can take up to a second for Redis
to acknowledge the write.
