### PR TITLE
[#76800748] Allow outputting logs in JSON format

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ var (
 const versionNumber string = "0.1.0"
 
 func init() {
+	jsonFlag := flag.Bool("json", false, "output logs as JSON")
+
 	debugFlag := flag.Bool("debug", false, "debug logging")
 	quietFlag := flag.Bool("quiet", false, "surpress all logging except errors")
 	verboseFlag := flag.Bool("verbose", false, "verbose logging")
@@ -54,6 +56,10 @@ func init() {
 	}
 
 	log.SetOutput(os.Stderr)
+
+	if *jsonFlag {
+		log.SetFormatter(new(log.JSONFormatter))
+	}
 
 	if *versionFlag {
 		fmt.Println(versionNumber)


### PR DESCRIPTION
This change allows us to output the logs in JSON rather than plain
text. An application flag has been used rather than changing it over
directly so that we can gracefully move our infrastructure over to use
it.
