### PR TITLE
[#76261684] Test that HandleChannelClose() is called

### DIFF
--- a/queue/queue_connection_test.go
+++ b/queue/queue_connection_test.go
@@ -24,11 +24,11 @@ var _ = Describe("QueueConnection", func() {
 
 	Describe("Connection errors", func() {
 		var (
-			connection *QueueConnection
-			proxy      *util.ProxyTCP
-			proxyAddr  string           = "localhost:5673"
-			queueName  string           = "govuk_crawler_worker-test-crawler-queue"
-			fatalErrs  chan *amqp.Error = make(chan *amqp.Error)
+			connection       *QueueConnection
+			proxy            *util.ProxyTCP
+			proxyAddr        string           = "localhost:5673"
+			queueName        string           = "govuk_crawler_worker-test-crawler-queue"
+			fatalErrs        chan *amqp.Error = make(chan *amqp.Error)
 			channelCloseMsgs chan string      = make(chan string)
 		)
 


### PR DESCRIPTION
Test that `connection.HandleChannelClose()` is called on recoverable errors.

---

Also, simplify one of the related tests to avoid a type assertion.
