### PR TITLE
Tidy up sleep warning

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -7,4 +7,4 @@ gom 'github.com/onsi/ginkgo', :commit => '75d0cd9c7ee52e99b13e6ccfd9e58b4f92b779
 gom 'github.com/onsi/gomega', :commit => '835b5e4242c715976b98ed6bc6ece1d9c7879f66'
 gom 'github.com/quipo/statsd', :commit => 'c3f043b963777f5aa85795d29e6be3f6251c1beb'
 gom 'github.com/streadway/amqp', :commit => '6ffc9248c4b16699477e7411084c2402f2f0c351'
-gom 'golang.org/x/net/html', :commit => 'eb3aa32581e642b8f84f8103124a98c82e252b4e'
+gom 'golang.org/x/net/html', :commit => '8bc62b7ce1723e0e686c39f8fe3c5e8d03c8524c'

--- a/workflow.go
+++ b/workflow.go
@@ -123,7 +123,7 @@ func CrawlURL(
 						sleepTime := 5 * time.Second
 
 						// Back off from crawling for a few seconds.
-						log.Warningln("Sleeping for: ", sleepTime, " seconds. Received 429 HTTP status")
+						log.Warningf("Sleeping for: %v. Received 429 HTTP status", sleepTime)
 						time.Sleep(sleepTime)
 					}
 


### PR DESCRIPTION
Previously, this warning outputted:

    Sleeping for:  5s  seconds. Received 429 HTTP status

It will now output:

    Sleeping for: 5s. Received 429 HTTP status

Go's `time.Duration` type automatically includes a `s` unit when
printed.

Also, use `log.Warningf()` rather than `log.Warningln()` for neatness.