### PR TITLE
Rename queue.QueueConnection to queue.Connection

### DIFF
--- a/queue/queue_connection_test.go
+++ b/queue/queue_connection_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/streadway/amqp"
 )
 
-var _ = Describe("QueueConnection", func() {
+var _ = Describe("Connection", func() {
 	amqpAddr := util.GetEnvDefault("AMQP_ADDRESS", "amqp://guest:guest@localhost:5672/")
 
 	It("fails if it can't connect to an AMQP server", func() {
-		connection, err := NewQueueConnection("amqp://guest:guest@localhost:50000/")
+		connection, err := NewConnection("amqp://guest:guest@localhost:50000/")
 
 		Expect(err).ToNot(BeNil())
 		Expect(connection).To(BeNil())
@@ -24,7 +24,7 @@ var _ = Describe("QueueConnection", func() {
 
 	Describe("Connection errors", func() {
 		var (
-			connection       *QueueConnection
+			connection       *Connection
 			proxy            *util.ProxyTCP
 			proxyAddr        string           = "localhost:5673"
 			queueName        string           = "govuk_crawler_worker-test-crawler-queue"
@@ -42,7 +42,7 @@ var _ = Describe("QueueConnection", func() {
 			Expect(err).To(BeNil())
 			Expect(proxy).ToNot(BeNil())
 
-			connection, err = NewQueueConnection(proxyURL)
+			connection, err = NewConnection(proxyURL)
 			Expect(err).To(BeNil())
 			Expect(connection).ToNot(BeNil())
 
@@ -64,7 +64,7 @@ var _ = Describe("QueueConnection", func() {
 
 			// Assume existing connection is dead.
 			connection.Close()
-			connection, _ = NewQueueConnection(amqpAddr)
+			connection, _ = NewConnection(amqpAddr)
 
 			deleted, err := connection.Channel.QueueDelete(queueName, false, false, false)
 			Expect(err).To(BeNil())
@@ -108,12 +108,12 @@ var _ = Describe("QueueConnection", func() {
 
 	Describe("Connecting to a running AMQP service", func() {
 		var (
-			connection    *QueueConnection
+			connection    *Connection
 			connectionErr error
 		)
 
 		BeforeEach(func() {
-			connection, connectionErr = NewQueueConnection(amqpAddr)
+			connection, connectionErr = NewConnection(amqpAddr)
 			connection.HandleChannelClose = func(_ string) {}
 		})
 
@@ -183,8 +183,8 @@ var _ = Describe("QueueConnection", func() {
 
 	Describe("working with messages on the queue", func() {
 		var (
-			publisher *QueueConnection
-			consumer  *QueueConnection
+			publisher *Connection
+			consumer  *Connection
 			err       error
 		)
 
@@ -192,11 +192,11 @@ var _ = Describe("QueueConnection", func() {
 		queueName := "govuk_crawler_worker-test-crawler-queue"
 
 		BeforeEach(func() {
-			publisher, err = NewQueueConnection(amqpAddr)
+			publisher, err = NewConnection(amqpAddr)
 			Expect(err).To(BeNil())
 			Expect(publisher).ToNot(BeNil())
 
-			consumer, err = NewQueueConnection(amqpAddr)
+			consumer, err = NewConnection(amqpAddr)
 			Expect(err).To(BeNil())
 			Expect(consumer).ToNot(BeNil())
 

--- a/queue/queue_manager.go
+++ b/queue/queue_manager.go
@@ -7,17 +7,17 @@ import (
 type Manager struct {
 	ExchangeName string
 	QueueName    string
-	Consumer     *QueueConnection
-	Producer     *QueueConnection
+	Consumer     *Connection
+	Producer     *Connection
 }
 
 func NewManager(amqpAddr string, exchangeName string, queueName string) (*Manager, error) {
-	consumer, err := NewQueueConnection(amqpAddr)
+	consumer, err := NewConnection(amqpAddr)
 	if err != nil {
 		return nil, err
 	}
 
-	producer, err := NewQueueConnection(amqpAddr)
+	producer, err := NewConnection(amqpAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (h *Manager) Publish(
 		body)
 }
 
-func setupExchangeAndQueue(connection *QueueConnection, exchangeName string, queueName string) error {
+func setupExchangeAndQueue(connection *Connection, exchangeName string, queueName string) error {
 	var err error
 
 	err = connection.ExchangeDeclare(exchangeName, "topic")


### PR DESCRIPTION
Similar to 6d64219c, rename the struct to make it less awkward when
qualified with its package name, `queue`.

Renaming this causes some ambiguity in `workflow_test.go` because the
`queue` package's exported identifiers have been imported into the test
source file and, as such, are accessed without the qualifying `queue`
prefix. But I think that's a smell that we should fix at some point.