### PR TITLE
Upgrade Go to version 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: go
 
 go:
-  - 1.2
-  - 1.3
+  - 1.4
 
 before_install:
   - go get github.com/mattn/gom
-
-matrix:
-  allow_failures:
-    - go: 1.3
-  fast_finish: true
 
 services:
   - rabbitmq

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ from a message queue and crawl them, saving the output to disk.
 
 To run this worker you will need:
 
- - Go 1.2
+ - Go 1.4
  - [RabbitMQ](https://www.rabbitmq.com/)
  - [Redis](http://redis.io/)
 


### PR DESCRIPTION
Upgrade the Go version we test to 1.4 and remove versions 1.2 and 1.3
from the matrix build.

I don't see the value in testing older Go versions since:

a) supporting multiple versions of Go in Production (generally) is less of an issue
compared to interpreted languages since it compiles to a binary

b) Go's [compatability promise][] means that newer versions in the 1.x
branch should not break backwards-compatibility, so there's little
reason not to use the latest version

[compatability promise]: https://golang.org/doc/go1compat