### PR TITLE
Remove dot imports

### DIFF
--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	. "github.com/alphagov/govuk_crawler_worker"
-	. "github.com/alphagov/govuk_crawler_worker/http_crawler"
+	"github.com/alphagov/govuk_crawler_worker/http_crawler"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -42,7 +42,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 <body><h1>TEST</h1></body>
 </html>
 `)
-		item.Response = &CrawlerResponse{Body: html}
+		item.Response = &http_crawler.CrawlerResponse{Body: html}
 	})
 
 	AfterEach(func() {
@@ -60,7 +60,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 
 		It("can set the Response.Body of the crawled URL", func() {
 			item := NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: []byte("foo")}
+			item.Response = &http_crawler.CrawlerResponse{Body: []byte("foo")}
 
 			Expect(item.Response.Body).To(Equal([]byte("foo")))
 		})
@@ -82,7 +82,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("test/url.html"))
 		})
@@ -92,7 +92,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("one/three.html"))
 		})
@@ -102,7 +102,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("test/UPPER/MiXeD.html"))
 		})
@@ -112,7 +112,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("test/!T@e£s$t/U^R*L(){}.html"))
 		})
@@ -122,7 +122,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("test/one-two--three---.html"))
 		})
@@ -132,7 +132,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal(`test/如何在香港申請英國簽證.html`))
 		})
@@ -142,7 +142,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("this/url/has/a/trailing/slash/index.html"))
 		})
@@ -152,7 +152,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("index.html"))
 		})
@@ -161,7 +161,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery := amqp.Delivery{Body: []byte(testURL + "?foo=bar")}
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("government/organisations.html"))
 		})
@@ -170,7 +170,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery := amqp.Delivery{Body: []byte(testURL + "#foo")}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("government/organisations.html"))
 		})
@@ -180,7 +180,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: []byte(""), ContentType: ATOM}
+			item.Response = &http_crawler.CrawlerResponse{Body: []byte(""), ContentType: ATOM}
 
 			Expect(item.RelativeFilePath()).To(Equal("things.atom"))
 		})
@@ -190,7 +190,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: []byte(""), ContentType: JSON}
+			item.Response = &http_crawler.CrawlerResponse{Body: []byte(""), ContentType: JSON}
 
 			Expect(item.RelativeFilePath()).To(Equal("api.json"))
 		})
@@ -296,7 +296,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 
 		It("removes paths that are blacklisted", func() {
 			item := NewCrawlerMessageItem(delivery, rootURL, []string{"/trade-tariff"})
-			item.Response = &CrawlerResponse{
+			item.Response = &http_crawler.CrawlerResponse{
 				Body: []byte(`<div><a href="/foo/bar">a</a><a href="/trade-tariff">b</a></div>`),
 			}
 

--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"net/url"
 
-	. "github.com/alphagov/govuk_crawler_worker"
+	"github.com/alphagov/govuk_crawler_worker"
 	"github.com/alphagov/govuk_crawler_worker/http_crawler"
 
 	. "github.com/onsi/ginkgo"
@@ -20,7 +20,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 	var delivery amqp.Delivery
 	var err error
 	var html []byte
-	var item *CrawlerMessageItem
+	var item *main.CrawlerMessageItem
 	var rootURL *url.URL
 
 	BeforeEach(func() {
@@ -35,7 +35,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 		urlPath = "/government/organisations"
 
 		delivery = amqp.Delivery{Body: []byte(testURL)}
-		item = NewCrawlerMessageItem(delivery, rootURL, []string{})
+		item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
 
 		html = []byte(`<html>
 <head><title>test</title</head>
@@ -50,7 +50,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 	})
 
 	It("generates a CrawlerMessageItem object", func() {
-		Expect(NewCrawlerMessageItem(delivery, rootURL, []string{})).ToNot(BeNil())
+		Expect(main.NewCrawlerMessageItem(delivery, rootURL, []string{})).ToNot(BeNil())
 	})
 
 	Describe("getting and setting the Response.Body", func() {
@@ -59,7 +59,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 		})
 
 		It("can set the Response.Body of the crawled URL", func() {
-			item := NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item := main.NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &http_crawler.CrawlerResponse{Body: []byte("foo")}
 
 			Expect(item.Response.Body).To(Equal([]byte("foo")))
@@ -68,7 +68,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 
 	It("detects when a URL is blacklisted", func() {
 		delivery = amqp.Delivery{Body: []byte("https://www.example.com/blacklisted")}
-		item := NewCrawlerMessageItem(delivery, rootURL, []string{"/blacklisted"})
+		item := main.NewCrawlerMessageItem(delivery, rootURL, []string{"/blacklisted"})
 		Expect(item.IsBlacklisted()).To(BeTrue())
 	})
 
@@ -81,8 +81,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = "https://user:pass@example.com:8080/test/url"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("test/url.html"))
 		})
@@ -91,8 +91,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + "/../../one/./two/../three"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("one/three.html"))
 		})
@@ -101,8 +101,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + "/test/UPPER/MiXeD"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("test/UPPER/MiXeD.html"))
 		})
@@ -111,8 +111,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + "/test/!T@e£s$t/U^R*L(){}"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("test/!T@e£s$t/U^R*L(){}.html"))
 		})
@@ -121,8 +121,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + "/test/one-two--three---"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("test/one-two--three---.html"))
 		})
@@ -131,8 +131,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + `/test/如何在香港申請英國簽證`
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal(`test/如何在香港申請英國簽證.html`))
 		})
@@ -141,8 +141,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + "/this/url/has/a/trailing/slash/"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("this/url/has/a/trailing/slash/index.html"))
 		})
@@ -151,17 +151,17 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + "/"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("index.html"))
 		})
 
 		It("omits URL query parameters", func() {
 			delivery := amqp.Delivery{Body: []byte(testURL + "?foo=bar")}
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
 
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("government/organisations.html"))
 		})
@@ -169,8 +169,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 		It("omits URL fragments", func() {
 			delivery := amqp.Delivery{Body: []byte(testURL + "#foo")}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: HTML}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: html, ContentType: http_crawler.HTML}
 
 			Expect(item.RelativeFilePath()).To(Equal("government/organisations.html"))
 		})
@@ -179,8 +179,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + "/things.atom"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: []byte(""), ContentType: ATOM}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: []byte(""), ContentType: http_crawler.ATOM}
 
 			Expect(item.RelativeFilePath()).To(Equal("things.atom"))
 		})
@@ -189,8 +189,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL = rootURL.String() + "/api.json"
 			delivery = amqp.Delivery{Body: []byte(testURL)}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &http_crawler.CrawlerResponse{Body: []byte(""), ContentType: JSON}
+			item = main.NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item.Response = &http_crawler.CrawlerResponse{Body: []byte(""), ContentType: http_crawler.JSON}
 
 			Expect(item.RelativeFilePath()).To(Equal("api.json"))
 		})
@@ -295,7 +295,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 		})
 
 		It("removes paths that are blacklisted", func() {
-			item := NewCrawlerMessageItem(delivery, rootURL, []string{"/trade-tariff"})
+			item := main.NewCrawlerMessageItem(delivery, rootURL, []string{"/trade-tariff"})
 			item.Response = &http_crawler.CrawlerResponse{
 				Body: []byte(`<div><a href="/foo/bar">a</a><a href="/trade-tariff">b</a></div>`),
 			}

--- a/health_check_test.go
+++ b/health_check_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/alphagov/govuk_crawler_worker"
+	"github.com/alphagov/govuk_crawler_worker"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -54,8 +54,8 @@ var _ = Describe("HealthCheck", func() {
 		queueManager.Close()
 		ttlHashSet.Close()
 
-		healthCheck := NewHealthCheck(queueManager, ttlHashSet)
-		Expect(healthCheck.Status()).To(Equal(&Status{
+		healthCheck := main.NewHealthCheck(queueManager, ttlHashSet)
+		Expect(healthCheck.Status()).To(Equal(&main.Status{
 			AMQP:  false,
 			Redis: false,
 		}))
@@ -89,15 +89,15 @@ var _ = Describe("HealthCheck", func() {
 		})
 
 		It("should return a status struct showing the status of RabbitMQ and Redis", func() {
-			healthCheck := NewHealthCheck(queueManager, ttlHashSet)
-			Expect(healthCheck.Status()).To(Equal(&Status{
+			healthCheck := main.NewHealthCheck(queueManager, ttlHashSet)
+			Expect(healthCheck.Status()).To(Equal(&main.Status{
 				AMQP:  true,
 				Redis: true,
 			}))
 		})
 
 		It("provides an HTTP handler for marshalling the response to an HTTP server", func() {
-			healthCheck := NewHealthCheck(queueManager, ttlHashSet)
+			healthCheck := main.NewHealthCheck(queueManager, ttlHashSet)
 			handler := healthCheck.HTTPHandler()
 
 			w := httptest.NewRecorder()
@@ -127,10 +127,10 @@ var _ = Describe("HealthCheck", func() {
 		})
 
 		It("should show AMQP as down if the Producer is down", func() {
-			healthCheck := NewHealthCheck(queueManager, ttlHashSet)
+			healthCheck := main.NewHealthCheck(queueManager, ttlHashSet)
 			queueManager.Producer.Close()
 
-			Expect(healthCheck.Status()).To(Equal(&Status{
+			Expect(healthCheck.Status()).To(Equal(&main.Status{
 				AMQP:  false,
 				Redis: true,
 			}))
@@ -147,10 +147,10 @@ var _ = Describe("HealthCheck", func() {
 		})
 
 		It("should show AMQP as down if the Consumer is down", func() {
-			healthCheck := NewHealthCheck(queueManager, ttlHashSet)
+			healthCheck := main.NewHealthCheck(queueManager, ttlHashSet)
 			queueManager.Consumer.Close()
 
-			Expect(healthCheck.Status()).To(Equal(&Status{
+			Expect(healthCheck.Status()).To(Equal(&main.Status{
 				AMQP:  false,
 				Redis: true,
 			}))

--- a/http_crawler/crawler_response_test.go
+++ b/http_crawler/crawler_response_test.go
@@ -1,17 +1,17 @@
 package http_crawler_test
 
 import (
-	. "github.com/alphagov/govuk_crawler_worker/http_crawler"
+	"github.com/alphagov/govuk_crawler_worker/http_crawler"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("CrawlerResponse", func() {
-	var response *CrawlerResponse
+	var response *http_crawler.CrawlerResponse
 
 	BeforeEach(func() {
-		response = &CrawlerResponse{}
+		response = &http_crawler.CrawlerResponse{}
 	})
 
 	Describe("AcceptedContentType", func() {
@@ -24,8 +24,24 @@ var _ = Describe("CrawlerResponse", func() {
 			for _, contentType := range []string{
 				// Provide one with a charset to be sure.
 				"text/html; charset=utf-8",
-				ATOM, CSS, CSV, DOCX, GIF, HTML, ICO, ICS, JAVASCRIPT,
-				JPEG, JSON, ODP, ODS, ODT, PDF, PNG, XLS, XLSX,
+				http_crawler.ATOM,
+				http_crawler.CSS,
+				http_crawler.CSV,
+				http_crawler.DOCX,
+				http_crawler.GIF,
+				http_crawler.HTML,
+				http_crawler.ICO,
+				http_crawler.ICS,
+				http_crawler.JAVASCRIPT,
+				http_crawler.JPEG,
+				http_crawler.JSON,
+				http_crawler.ODP,
+				http_crawler.ODS,
+				http_crawler.ODT,
+				http_crawler.PDF,
+				http_crawler.PNG,
+				http_crawler.XLS,
+				http_crawler.XLSX,
 			} {
 				response.ContentType = contentType
 				Expect(response.AcceptedContentType()).To(BeTrue())
@@ -35,7 +51,7 @@ var _ = Describe("CrawlerResponse", func() {
 
 	Describe("ContentType", func() {
 		It("returns the error if we can't parse the content type", func() {
-			response := &CrawlerResponse{}
+			response := &http_crawler.CrawlerResponse{}
 			mime, err := response.ParseContentType()
 
 			Expect(mime).To(BeEmpty())
@@ -43,11 +59,11 @@ var _ = Describe("CrawlerResponse", func() {
 		})
 
 		It("returns the simplified mime type of the HTTP Content-Type value", func() {
-			response := &CrawlerResponse{ContentType: "application/json; charset=utf-8"}
+			response := &http_crawler.CrawlerResponse{ContentType: "application/json; charset=utf-8"}
 
 			mime, err := response.ParseContentType()
 
-			Expect(mime).To(Equal(JSON))
+			Expect(mime).To(Equal(http_crawler.JSON))
 			Expect(err).To(BeNil())
 		})
 	})

--- a/http_crawler/crawler_test.go
+++ b/http_crawler/crawler_test.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strings"
 
-	. "github.com/alphagov/govuk_crawler_worker/http_crawler"
+	"github.com/alphagov/govuk_crawler_worker/http_crawler"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,18 +24,18 @@ func testServer(status int, body string) *httptest.Server {
 }
 
 var _ = Describe("Crawl", func() {
-	var crawler *Crawler
+	var crawler *http_crawler.Crawler
 
 	BeforeEach(func() {
 		rootURL, _ := url.Parse("http://127.0.0.1")
-		crawler = NewCrawler(rootURL, "0.0.0", nil)
+		crawler = http_crawler.NewCrawler(rootURL, "0.0.0", nil)
 		Expect(crawler).ToNot(BeNil())
 	})
 
-	Describe("NewCrawler()", func() {
+	Describe("http_crawler.NewCrawler()", func() {
 		It("provides a new crawler that accepts the provided host", func() {
 			rootURL, _ := url.Parse("https://www.gov.uk/")
-			GOVUKCrawler := NewCrawler(rootURL, "0.0.0", nil)
+			GOVUKCrawler := http_crawler.NewCrawler(rootURL, "0.0.0", nil)
 			Expect(GOVUKCrawler.RootURL.Host).To(Equal("www.gov.uk"))
 		})
 
@@ -65,7 +65,7 @@ var _ = Describe("Crawl", func() {
 			defer basicAuthTestServer.Close()
 
 			rootURL, _ := url.Parse("http://127.0.0.1")
-			basicAuthCrawler := NewCrawler(rootURL, "0.0.0", &BasicAuth{"username", "password"})
+			basicAuthCrawler := http_crawler.NewCrawler(rootURL, "0.0.0", &http_crawler.BasicAuth{"username", "password"})
 
 			testURL, _ := url.Parse(basicAuthTestServer.URL)
 			response, err := basicAuthCrawler.Crawl(testURL)
@@ -133,7 +133,7 @@ var _ = Describe("Crawl", func() {
 			testURL, _ := url.Parse("http://www.google.com/foo")
 			response, err := crawler.Crawl(testURL)
 
-			Expect(err).To(Equal(ErrCannotCrawlURL))
+			Expect(err).To(Equal(http_crawler.ErrCannotCrawlURL))
 			Expect(response).To(BeNil())
 		})
 
@@ -145,7 +145,7 @@ var _ = Describe("Crawl", func() {
 				testURL, _ := url.Parse(ts.URL)
 				response, err := crawler.Crawl(testURL)
 
-				Expect(err).To(Equal(ErrRetryRequest429))
+				Expect(err).To(Equal(http_crawler.ErrRetryRequest429))
 				Expect(response).To(BeNil())
 			})
 
@@ -156,7 +156,7 @@ var _ = Describe("Crawl", func() {
 				testURL, _ := url.Parse(ts.URL)
 				response, err := crawler.Crawl(testURL)
 
-				Expect(err).To(Equal(ErrRetryRequest5XX))
+				Expect(err).To(Equal(http_crawler.ErrRetryRequest5XX))
 				Expect(response).To(BeNil())
 			})
 
@@ -167,7 +167,7 @@ var _ = Describe("Crawl", func() {
 				testURL, _ := url.Parse(ts.URL)
 				response, err := crawler.Crawl(testURL)
 
-				Expect(err).To(Equal(ErrRetryRequest5XX))
+				Expect(err).To(Equal(http_crawler.ErrRetryRequest5XX))
 				Expect(response).To(BeNil())
 			})
 		})
@@ -175,7 +175,7 @@ var _ = Describe("Crawl", func() {
 
 	Describe("RetryStatusCodes", func() {
 		It("should return a fixed int array with values 429, 500..599", func() {
-			statusCodes := Retry5XXStatusCodes()
+			statusCodes := http_crawler.Retry5XXStatusCodes()
 
 			Expect(len(statusCodes)).To(Equal(100))
 			Expect(statusCodes[0]).To(Equal(500))

--- a/queue/queue_connection_test.go
+++ b/queue/queue_connection_test.go
@@ -1,7 +1,7 @@
 package queue_test
 
 import (
-	. "github.com/alphagov/govuk_crawler_worker/queue"
+	"github.com/alphagov/govuk_crawler_worker/queue"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,7 +16,7 @@ var _ = Describe("Connection", func() {
 	amqpAddr := util.GetEnvDefault("AMQP_ADDRESS", "amqp://guest:guest@localhost:5672/")
 
 	It("fails if it can't connect to an AMQP server", func() {
-		connection, err := NewConnection("amqp://guest:guest@localhost:50000/")
+		connection, err := queue.NewConnection("amqp://guest:guest@localhost:50000/")
 
 		Expect(err).ToNot(BeNil())
 		Expect(connection).To(BeNil())
@@ -24,7 +24,7 @@ var _ = Describe("Connection", func() {
 
 	Describe("Connection errors", func() {
 		var (
-			connection       *Connection
+			connection       *queue.Connection
 			proxy            *util.ProxyTCP
 			proxyAddr        string           = "localhost:5673"
 			queueName        string           = "govuk_crawler_worker-test-crawler-queue"
@@ -42,7 +42,7 @@ var _ = Describe("Connection", func() {
 			Expect(err).To(BeNil())
 			Expect(proxy).ToNot(BeNil())
 
-			connection, err = NewConnection(proxyURL)
+			connection, err = queue.NewConnection(proxyURL)
 			Expect(err).To(BeNil())
 			Expect(connection).ToNot(BeNil())
 
@@ -64,7 +64,7 @@ var _ = Describe("Connection", func() {
 
 			// Assume existing connection is dead.
 			connection.Close()
-			connection, _ = NewConnection(amqpAddr)
+			connection, _ = queue.NewConnection(amqpAddr)
 
 			deleted, err := connection.Channel.QueueDelete(queueName, false, false, false)
 			Expect(err).To(BeNil())
@@ -108,12 +108,12 @@ var _ = Describe("Connection", func() {
 
 	Describe("Connecting to a running AMQP service", func() {
 		var (
-			connection    *Connection
+			connection    *queue.Connection
 			connectionErr error
 		)
 
 		BeforeEach(func() {
-			connection, connectionErr = NewConnection(amqpAddr)
+			connection, connectionErr = queue.NewConnection(amqpAddr)
 			connection.HandleChannelClose = func(_ string) {}
 		})
 
@@ -183,8 +183,8 @@ var _ = Describe("Connection", func() {
 
 	Describe("working with messages on the queue", func() {
 		var (
-			publisher *Connection
-			consumer  *Connection
+			publisher *queue.Connection
+			consumer  *queue.Connection
 			err       error
 		)
 
@@ -192,11 +192,11 @@ var _ = Describe("Connection", func() {
 		queueName := "govuk_crawler_worker-test-crawler-queue"
 
 		BeforeEach(func() {
-			publisher, err = NewConnection(amqpAddr)
+			publisher, err = queue.NewConnection(amqpAddr)
 			Expect(err).To(BeNil())
 			Expect(publisher).ToNot(BeNil())
 
-			consumer, err = NewConnection(amqpAddr)
+			consumer, err = queue.NewConnection(amqpAddr)
 			Expect(err).To(BeNil())
 			Expect(consumer).ToNot(BeNil())
 

--- a/queue/queue_manager_test.go
+++ b/queue/queue_manager_test.go
@@ -1,7 +1,7 @@
 package queue_test
 
 import (
-	. "github.com/alphagov/govuk_crawler_worker/queue"
+	"github.com/alphagov/govuk_crawler_worker/queue"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,7 +13,7 @@ var _ = Describe("Manager", func() {
 	amqpAddr := util.GetEnvDefault("AMQP_ADDRESS", "amqp://guest:guest@localhost:5672/")
 
 	It("returns an error if passed a bad connection address", func() {
-		queueManager, err := NewManager(
+		queueManager, err := queue.NewManager(
 			"amqp://guest:guest@localhost:50000/",
 			"test-manager-exchange",
 			"test-manager-queue")
@@ -26,7 +26,7 @@ var _ = Describe("Manager", func() {
 		exchangeName := "govuk_crawler_worker-test-manager-exchange"
 		queueName := "govuk_crawler_worker-test-manager-queue"
 
-		queueManager, err := NewManager(
+		queueManager, err := queue.NewManager(
 			amqpAddr,
 			exchangeName,
 			queueName)
@@ -49,7 +49,7 @@ var _ = Describe("Manager", func() {
 
 	Describe("working with an AMQP service", func() {
 		var (
-			queueManager    *Manager
+			queueManager    *queue.Manager
 			queueManagerErr error
 		)
 
@@ -57,7 +57,7 @@ var _ = Describe("Manager", func() {
 		queueName := "govuk_crawler_worker-test-handler-queue"
 
 		BeforeEach(func() {
-			queueManager, queueManagerErr = NewManager(
+			queueManager, queueManagerErr = queue.NewManager(
 				amqpAddr,
 				exchangeName,
 				queueName)

--- a/ttl_hash_set/ttl_hash_set_test.go
+++ b/ttl_hash_set/ttl_hash_set_test.go
@@ -1,7 +1,7 @@
 package ttl_hash_set_test
 
 import (
-	. "github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
+	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,7 +17,7 @@ var _ = Describe("TTLHashSet", func() {
 	prefix := "govuk_mirror_crawler_test"
 
 	It("returns an error when asking for a TTLHashSet object that can't connect to redis", func() {
-		ttlHashSet, err := NewTTLHashSet(prefix, "127.0.0.1:20000", time.Hour)
+		ttlHashSet, err := ttl_hash_set.NewTTLHashSet(prefix, "127.0.0.1:20000", time.Hour)
 
 		Expect(err).ToNot(BeNil())
 		Expect(ttlHashSet).To(BeNil())
@@ -28,7 +28,7 @@ var _ = Describe("TTLHashSet", func() {
 			proxy         *util.ProxyTCP
 			proxyAddr     string = "127.0.0.1:6380"
 			key           string = "reconnect"
-			ttlHashSet    *TTLHashSet
+			ttlHashSet    *ttl_hash_set.TTLHashSet
 			reconnectTime time.Duration = 2 * time.Second
 			delayBetween  time.Duration = reconnectTime / 10
 		)
@@ -40,7 +40,7 @@ var _ = Describe("TTLHashSet", func() {
 			Expect(err).To(BeNil())
 			Expect(proxy).ToNot(BeNil())
 
-			ttlHashSet, err = NewTTLHashSet(prefix, proxyAddr, time.Hour)
+			ttlHashSet, err = ttl_hash_set.NewTTLHashSet(prefix, proxyAddr, time.Hour)
 
 			Expect(err).To(BeNil())
 			Expect(ttlHashSet).ToNot(BeNil())
@@ -107,12 +107,12 @@ var _ = Describe("TTLHashSet", func() {
 
 	Describe("Working with a redis service", func() {
 		var (
-			ttlHashSet    *TTLHashSet
+			ttlHashSet    *ttl_hash_set.TTLHashSet
 			ttlHashSetErr error
 		)
 
 		BeforeEach(func() {
-			ttlHashSet, ttlHashSetErr = NewTTLHashSet(prefix, redisAddr, time.Hour)
+			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour)
 		})
 
 		AfterEach(func() {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -12,7 +12,7 @@ import (
 
 	. "github.com/alphagov/govuk_crawler_worker"
 	"github.com/alphagov/govuk_crawler_worker/http_crawler"
-	. "github.com/alphagov/govuk_crawler_worker/queue"
+	"github.com/alphagov/govuk_crawler_worker/queue"
 	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -32,7 +32,7 @@ var _ = Describe("Workflow", func() {
 		var (
 			err             error
 			mirrorRoot      string
-			queueManager    *Manager
+			queueManager    *queue.Manager
 			queueManagerErr error
 			ttlHashSet      *ttl_hash_set.TTLHashSet
 			ttlHashSetErr   error
@@ -51,7 +51,7 @@ var _ = Describe("Workflow", func() {
 			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour)
 			Expect(ttlHashSetErr).To(BeNil())
 
-			queueManager, queueManagerErr = NewManager(
+			queueManager, queueManagerErr = queue.NewManager(
 				amqpAddr,
 				exchangeName,
 				queueName)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/alphagov/govuk_crawler_worker"
 	. "github.com/alphagov/govuk_crawler_worker/http_crawler"
 	. "github.com/alphagov/govuk_crawler_worker/queue"
-	. "github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
+	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -34,7 +34,7 @@ var _ = Describe("Workflow", func() {
 			mirrorRoot      string
 			queueManager    *Manager
 			queueManagerErr error
-			ttlHashSet      *TTLHashSet
+			ttlHashSet      *ttl_hash_set.TTLHashSet
 			ttlHashSetErr   error
 			rootURL         *url.URL
 		)
@@ -48,7 +48,7 @@ var _ = Describe("Workflow", func() {
 
 			rootURL, _ = url.Parse("https://www.gov.uk")
 
-			ttlHashSet, ttlHashSetErr = NewTTLHashSet(prefix, redisAddr, time.Hour)
+			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour)
 			Expect(ttlHashSetErr).To(BeNil())
 
 			queueManager, queueManagerErr = NewManager(

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"time"
 
-	. "github.com/alphagov/govuk_crawler_worker"
+	"github.com/alphagov/govuk_crawler_worker"
 	"github.com/alphagov/govuk_crawler_worker/http_crawler"
 	"github.com/alphagov/govuk_crawler_worker/queue"
 	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
@@ -92,20 +92,20 @@ var _ = Describe("Workflow", func() {
 				deliveries, err := queueManager.Consume()
 				Expect(err).To(BeNil())
 
-				outbound := make(chan *CrawlerMessageItem, 1)
+				outbound := make(chan *main.CrawlerMessageItem, 1)
 
 				err = queueManager.Publish("#", "text/plain", url)
 				Expect(err).To(BeNil())
 
 				for item := range deliveries {
-					outbound <- NewCrawlerMessageItem(item, rootURL, []string{})
+					outbound <- main.NewCrawlerMessageItem(item, rootURL, []string{})
 					item.Ack(false)
 					break
 				}
 
 				Expect(len(outbound)).To(Equal(1))
 
-				go AcknowledgeItem(outbound, ttlHashSet)
+				go main.AcknowledgeItem(outbound, ttlHashSet)
 
 				Eventually(outbound).Should(HaveLen(0))
 				Eventually(func() bool {
@@ -128,15 +128,15 @@ var _ = Describe("Workflow", func() {
 			})
 
 			It("crawls a URL and assigns the body", func() {
-				outbound := make(chan *CrawlerMessageItem, 1)
+				outbound := make(chan *main.CrawlerMessageItem, 1)
 
 				body := `<a href="gov.uk">bar</a>`
 				server := testServer(http.StatusOK, body)
 
 				deliveryItem := &amqp.Delivery{Body: []byte(server.URL)}
-				outbound <- NewCrawlerMessageItem(*deliveryItem, rootURL, []string{})
+				outbound <- main.NewCrawlerMessageItem(*deliveryItem, rootURL, []string{})
 
-				crawled := CrawlURL(ttlHashSet, outbound, crawler, 1, 1)
+				crawled := main.CrawlURL(ttlHashSet, outbound, crawler, 1, 1)
 
 				Expect((<-crawled).Response.Body[0:24]).To(Equal([]byte(body)))
 
@@ -151,7 +151,7 @@ var _ = Describe("Workflow", func() {
 				deliveries, err := queueManager.Consume()
 				Expect(err).To(BeNil())
 
-				crawlChan := ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
+				crawlChan := main.ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
 				Expect(len(crawlChan)).To(Equal(0))
 
 				maxRetries := 4
@@ -160,7 +160,7 @@ var _ = Describe("Workflow", func() {
 				Expect(err).To(BeNil())
 				Eventually(crawlChan).Should(HaveLen(1))
 
-				crawled := CrawlURL(ttlHashSet, crawlChan, crawler, 1, maxRetries)
+				crawled := main.CrawlURL(ttlHashSet, crawlChan, crawler, 1, maxRetries)
 				Eventually(crawlChan).Should(HaveLen(0))
 
 				Eventually(func() (int, error) {
@@ -184,7 +184,7 @@ var _ = Describe("Workflow", func() {
 				deliveries, err := queueManager.Consume()
 				Expect(err).To(BeNil())
 
-				crawlChan := ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
+				crawlChan := main.ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
 				Expect(len(crawlChan)).To(Equal(0))
 
 				maxRetries := 4
@@ -193,12 +193,12 @@ var _ = Describe("Workflow", func() {
 				Expect(err).To(BeNil())
 				Eventually(crawlChan).Should(HaveLen(1))
 
-				crawled := CrawlURL(ttlHashSet, crawlChan, crawler, 1, maxRetries)
+				crawled := main.CrawlURL(ttlHashSet, crawlChan, crawler, 1, maxRetries)
 				Eventually(crawlChan).Should(HaveLen(0))
 
 				Eventually(func() (int, error) {
 					return ttlHashSet.Get(server.URL)
-				}).Should(Equal(AlreadyCrawled))
+				}).Should(Equal(main.AlreadyCrawled))
 
 				Eventually(func() (int, error) {
 					queueInfo, err := queueManager.Producer.Channel.QueueInspect(queueManager.QueueName)
@@ -217,7 +217,7 @@ var _ = Describe("Workflow", func() {
 				deliveries, err := queueManager.Consume()
 				Expect(err).To(BeNil())
 
-				crawlChan := ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
+				crawlChan := main.ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
 				Expect(len(crawlChan)).To(Equal(0))
 
 				maxRetries := 4
@@ -226,12 +226,12 @@ var _ = Describe("Workflow", func() {
 				Expect(err).To(BeNil())
 				Eventually(crawlChan).Should(HaveLen(1))
 
-				crawled := CrawlURL(ttlHashSet, crawlChan, crawler, 1, maxRetries)
+				crawled := main.CrawlURL(ttlHashSet, crawlChan, crawler, 1, maxRetries)
 				Eventually(crawlChan).Should(HaveLen(0))
 
 				Eventually(func() (int, error) {
 					return ttlHashSet.Get(server.URL)
-				}).Should(Equal(AlreadyCrawled))
+				}).Should(Equal(main.AlreadyCrawled))
 
 				Eventually(func() (int, error) {
 					queueInfo, err := queueManager.Producer.Channel.QueueInspect(queueManager.QueueName)
@@ -244,14 +244,14 @@ var _ = Describe("Workflow", func() {
 			})
 
 			It("expects the number of goroutines to run to be a positive integer", func() {
-				outbound := make(chan *CrawlerMessageItem, 1)
+				outbound := make(chan *main.CrawlerMessageItem, 1)
 
 				Expect(func() {
-					CrawlURL(ttlHashSet, outbound, crawler, 0, 1)
+					main.CrawlURL(ttlHashSet, outbound, crawler, 0, 1)
 				}).To(Panic())
 
 				Expect(func() {
-					CrawlURL(ttlHashSet, outbound, crawler, -1, 1)
+					main.CrawlURL(ttlHashSet, outbound, crawler, -1, 1)
 				}).To(Panic())
 			})
 		})
@@ -260,14 +260,14 @@ var _ = Describe("Workflow", func() {
 			It("wrote the item to disk", func() {
 				url := "https://www.gov.uk/extract-some-urls"
 				deliveryItem := &amqp.Delivery{Body: []byte(url)}
-				item := NewCrawlerMessageItem(*deliveryItem, rootURL, []string{})
+				item := main.NewCrawlerMessageItem(*deliveryItem, rootURL, []string{})
 				item.Response = &http_crawler.CrawlerResponse{
 					Body:        []byte(`<a href="https://www.gov.uk/some-url">a link</a>`),
-					ContentType: HTML,
+					ContentType: http_crawler.HTML,
 				}
 
-				outbound := make(chan *CrawlerMessageItem, 1)
-				extract := WriteItemToDisk(mirrorRoot, outbound)
+				outbound := make(chan *main.CrawlerMessageItem, 1)
+				extract := main.WriteItemToDisk(mirrorRoot, outbound)
 
 				Expect(len(extract)).To(Equal(0))
 
@@ -295,14 +295,14 @@ var _ = Describe("Workflow", func() {
 				Expect(err).To(BeNil())
 
 				rootURL, _ := url.Parse("https://www.gov.uk")
-				item := NewCrawlerMessageItem((<-deliveries), rootURL, []string{})
+				item := main.NewCrawlerMessageItem((<-deliveries), rootURL, []string{})
 				item.Response = &http_crawler.CrawlerResponse{
 					Body:        body,
-					ContentType: JSON,
+					ContentType: http_crawler.JSON,
 				}
 
-				outbound := make(chan *CrawlerMessageItem, 1)
-				extract := WriteItemToDisk(mirrorRoot, outbound)
+				outbound := make(chan *main.CrawlerMessageItem, 1)
+				extract := main.WriteItemToDisk(mirrorRoot, outbound)
 				Expect(len(extract)).To(Equal(0))
 
 				outbound <- item
@@ -322,13 +322,13 @@ var _ = Describe("Workflow", func() {
 			It("extracts URLs from the HTML body and adds them to a new channel; acknowledging item", func() {
 				url := "https://www.gov.uk/extract-some-urls"
 				deliveryItem := &amqp.Delivery{Body: []byte(url)}
-				item := NewCrawlerMessageItem(*deliveryItem, rootURL, []string{})
+				item := main.NewCrawlerMessageItem(*deliveryItem, rootURL, []string{})
 				item.Response = &http_crawler.CrawlerResponse{
 					Body: []byte(`<a href="https://www.gov.uk/some-url">a link</a>`),
 				}
 
-				outbound := make(chan *CrawlerMessageItem, 1)
-				publish, acknowledge := ExtractURLs(outbound)
+				outbound := make(chan *main.CrawlerMessageItem, 1)
+				publish, acknowledge := main.ExtractURLs(outbound)
 
 				Expect(len(publish)).To(Equal(0))
 				Expect(len(acknowledge)).To(Equal(0))
@@ -362,7 +362,7 @@ var _ = Describe("Workflow", func() {
 						item.Ack(false)
 					}
 				}()
-				go PublishURLs(ttlHashSet, queueManager, publish)
+				go main.PublishURLs(ttlHashSet, queueManager, publish)
 
 				publish <- url
 				Expect(len(publish)).To(Equal(1))
@@ -391,7 +391,7 @@ var _ = Describe("Workflow", func() {
 						item.Ack(false)
 					}
 				}()
-				go PublishURLs(ttlHashSet, queueManager, publish)
+				go main.PublishURLs(ttlHashSet, queueManager, publish)
 
 				publish <- url
 
@@ -408,7 +408,7 @@ var _ = Describe("Workflow", func() {
 				deliveries, err := queueManager.Consume()
 				Expect(err).To(BeNil())
 
-				outbound := ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
+				outbound := main.ReadFromQueue(deliveries, rootURL, ttlHashSet, []string{}, 1)
 				Expect(len(outbound)).To(Equal(0))
 
 				url := "https://www.gov.uk/bar"
@@ -444,7 +444,7 @@ var _ = Describe("Workflow", func() {
 				}()
 				Eventually(deliveriesBuffer).Should(HaveLen(1))
 
-				ReadFromQueue(deliveriesBuffer, rootURL, ttlHashSet, []string{"/blacklisted"}, 1)
+				main.ReadFromQueue(deliveriesBuffer, rootURL, ttlHashSet, []string{"/blacklisted"}, 1)
 
 				Eventually(func() (int, error) {
 					queueInfo, err := queueManager.Producer.Channel.QueueInspect(queueManager.QueueName)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	. "github.com/alphagov/govuk_crawler_worker"
-	. "github.com/alphagov/govuk_crawler_worker/http_crawler"
+	"github.com/alphagov/govuk_crawler_worker/http_crawler"
 	. "github.com/alphagov/govuk_crawler_worker/queue"
 	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 	. "github.com/onsi/ginkgo"
@@ -119,11 +119,11 @@ var _ = Describe("Workflow", func() {
 		})
 
 		Describe("CrawlURL", func() {
-			var crawler *Crawler
+			var crawler *http_crawler.Crawler
 
 			BeforeEach(func() {
 				rootURL, _ = url.Parse("http://127.0.0.1")
-				crawler = NewCrawler(rootURL, "0.0.0", nil)
+				crawler = http_crawler.NewCrawler(rootURL, "0.0.0", nil)
 				Expect(crawler).ToNot(BeNil())
 			})
 
@@ -261,7 +261,7 @@ var _ = Describe("Workflow", func() {
 				url := "https://www.gov.uk/extract-some-urls"
 				deliveryItem := &amqp.Delivery{Body: []byte(url)}
 				item := NewCrawlerMessageItem(*deliveryItem, rootURL, []string{})
-				item.Response = &CrawlerResponse{
+				item.Response = &http_crawler.CrawlerResponse{
 					Body:        []byte(`<a href="https://www.gov.uk/some-url">a link</a>`),
 					ContentType: HTML,
 				}
@@ -296,7 +296,7 @@ var _ = Describe("Workflow", func() {
 
 				rootURL, _ := url.Parse("https://www.gov.uk")
 				item := NewCrawlerMessageItem((<-deliveries), rootURL, []string{})
-				item.Response = &CrawlerResponse{
+				item.Response = &http_crawler.CrawlerResponse{
 					Body:        body,
 					ContentType: JSON,
 				}
@@ -323,7 +323,7 @@ var _ = Describe("Workflow", func() {
 				url := "https://www.gov.uk/extract-some-urls"
 				deliveryItem := &amqp.Delivery{Body: []byte(url)}
 				item := NewCrawlerMessageItem(*deliveryItem, rootURL, []string{})
-				item.Response = &CrawlerResponse{
+				item.Response = &http_crawler.CrawlerResponse{
 					Body: []byte(`<a href="https://www.gov.uk/some-url">a link</a>`),
 				}
 


### PR DESCRIPTION
Dot imports are discouraged because they make it difficult to determine
to which package an identifier belongs. By properly namespacing the
code, it's easier to understand how each package is used.

See:
https://github.com/golang/go/wiki/CodeReviewComments#import-dot

> Except for this one case, do not use import . in your programs. It
> makes the programs much harder to read because it is unclear whether a
> name like Quux is a top-level identifier in the current package or in
> an imported package.

Note that I've not removed the 'dot import' for the Ginkgo or Gomega packages as I think it would make the tests harder to read and add unnecessary boilerplate.