### PR TITLE
[#58334884] Support multiple rootURLs

### DIFF
--- a/crawler_message_item.go
+++ b/crawler_message_item.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/url"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -42,6 +43,7 @@ func (c *CrawlerMessageItem) RelativeFilePath() (string, error) {
 	}
 
 	filePath = urlParts.Path
+	host := strings.SplitN(urlParts.Host, ":", 2)[0]
 
 	contentType, err := c.Response.ParseContentType()
 	if err != nil {
@@ -64,6 +66,7 @@ func (c *CrawlerMessageItem) RelativeFilePath() (string, error) {
 	}
 
 	filePath = path.Clean(filePath)
+	filePath = filepath.Join(host, filePath)
 	filePath = strings.TrimPrefix(filePath, "/")
 
 	return filePath, nil

--- a/crawler_message_item.go
+++ b/crawler_message_item.go
@@ -18,14 +18,14 @@ type CrawlerMessageItem struct {
 	amqp.Delivery
 	Response *http_crawler.CrawlerResponse
 
-	rootURL        *url.URL
+	rootURLs       []*url.URL
 	blacklistPaths []string
 }
 
-func NewCrawlerMessageItem(delivery amqp.Delivery, rootURL *url.URL, blacklistPaths []string) *CrawlerMessageItem {
+func NewCrawlerMessageItem(delivery amqp.Delivery, rootURLs []*url.URL, blacklistPaths []string) *CrawlerMessageItem {
 	return &CrawlerMessageItem{
 		Delivery:       delivery,
-		rootURL:        rootURL,
+		rootURLs:       rootURLs,
 		blacklistPaths: blacklistPaths,
 	}
 }
@@ -100,8 +100,12 @@ func (c *CrawlerMessageItem) ExtractURLs() ([]*url.URL, error) {
 			return extractedURLs, err
 		}
 
-		urls = convertURLsToAbsolute(c.rootURL, urls)
-		urls = filterURLsByHost(c.rootURL.Host, urls)
+		baseURL := &url.URL{
+			Scheme: c.Response.URL.Scheme,
+			Host:   c.Response.URL.Host,
+		}
+		urls = convertURLsToAbsolute(baseURL, urls)
+		urls = filterURLsByHost(c.rootURLs, urls)
 		urls = filterBlacklistedURLs(c.blacklistPaths, urls)
 		urls = removeFragmentFromURLs(urls)
 
@@ -137,9 +141,9 @@ func parseURLs(urls []string) ([]*url.URL, error) {
 	return parsedURLs, err
 }
 
-func convertURLsToAbsolute(rootURL *url.URL, urls []*url.URL) []*url.URL {
+func convertURLsToAbsolute(baseURL *url.URL, urls []*url.URL) []*url.URL {
 	return mapURLs(urls, func(url *url.URL) *url.URL {
-		return rootURL.ResolveReference(url)
+		return baseURL.ResolveReference(url)
 	})
 }
 
@@ -150,10 +154,14 @@ func removeFragmentFromURLs(urls []*url.URL) []*url.URL {
 	})
 }
 
-func filterURLsByHost(host string, urls []*url.URL) []*url.URL {
-	return filterURLs(urls, func(url *url.URL) bool {
-		return url.Host == host
-	})
+func filterURLsByHost(allowedHosts []*url.URL, urls []*url.URL) (ret []*url.URL) {
+	for _, allowed := range allowedHosts {
+		ret = append(ret, filterURLs(urls, func(url *url.URL) bool {
+			return url.Host == allowed.Host
+		})...)
+	}
+
+	return ret
 }
 
 func filterBlacklistedURLs(blacklistedPaths []string, urls []*url.URL) []*url.URL {

--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -100,7 +100,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("test/url.html"))
+			Expect(item.RelativeFilePath()).To(Equal("example.com/test/url.html"))
 		})
 
 		It("strips preceeding path traversals and resolves the remaining path", func() {
@@ -110,7 +110,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("one/three.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/one/three.html"))
 		})
 
 		It("preserves case sensitivity", func() {
@@ -120,7 +120,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("test/UPPER/MiXeD.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/UPPER/MiXeD.html"))
 		})
 
 		It("preserves non-alphanumeric characters", func() {
@@ -130,7 +130,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("test/!T@e£s$t/U^R*L(){}.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/!T@e£s$t/U^R*L(){}.html"))
 		})
 
 		It("preserves multiple dashes", func() {
@@ -140,7 +140,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("test/one-two--three---.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/one-two--three---.html"))
 		})
 
 		It("preserves non-latin chars and not URL encode them", func() {
@@ -150,7 +150,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("test/如何在香港申請英國簽證.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/如何在香港申請英國簽證.html"))
 		})
 
 		It("adds an index.html suffix when URL references a directory", func() {
@@ -160,7 +160,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("this/url/has/a/trailing/slash/index.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/this/url/has/a/trailing/slash/index.html"))
 		})
 
 		It("adds an index.html suffix when URL has no path and no trailing slash", func() {
@@ -170,7 +170,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("index.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/index.html"))
 		})
 
 		It("omits URL query parameters", func() {
@@ -179,7 +179,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("government/organisations.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/government/organisations.html"))
 		})
 
 		It("omits URL fragments", func() {
@@ -188,7 +188,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
 
-			Expect(item.RelativeFilePath()).To(Equal("government/organisations.html"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/government/organisations.html"))
 		})
 
 		It("supports ATOM URLs", func() {
@@ -198,7 +198,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: []byte(""), ContentType: ATOM}
 
-			Expect(item.RelativeFilePath()).To(Equal("things.atom"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/things.atom"))
 		})
 
 		It("supports JSON URLs", func() {
@@ -208,7 +208,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
 			item.Response = &CrawlerResponse{Body: []byte(""), ContentType: JSON}
 
-			Expect(item.RelativeFilePath()).To(Equal("api.json"))
+			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/api.json"))
 		})
 	})
 

--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -17,12 +17,13 @@ import (
 
 var _ = Describe("CrawlerMessageItem", func() {
 	var (
-		mirrorRoot       string
-		delivery         amqp.Delivery
-		err              error
-		html             []byte
-		item             *CrawlerMessageItem
-		rootURL, testURL *url.URL
+		mirrorRoot                string
+		delivery                  amqp.Delivery
+		err                       error
+		html                      []byte
+		item                      *CrawlerMessageItem
+		rootURLs                  []*url.URL
+		testURL, urlA, urlB, urlC *url.URL
 	)
 
 	BeforeEach(func() {
@@ -38,21 +39,36 @@ var _ = Describe("CrawlerMessageItem", func() {
 			Path:   "/government/organisations",
 		}
 
-		rootURL = &url.URL{
+		delivery = amqp.Delivery{Body: []byte(testURL.String())}
+		item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+
+		urlA = &url.URL{
 			Scheme: "https",
 			Host:   "www.gov.uk",
 			Path:   "/",
 		}
-
-		delivery = amqp.Delivery{Body: []byte(testURL.String())}
-		item = NewCrawlerMessageItem(delivery, rootURL, []string{})
+		urlB = &url.URL{
+			Scheme: "https",
+			Host:   "assets.digital.cabinet-office.gov.uk",
+			Path:   "/",
+		}
+		urlC = &url.URL{
+			Scheme: "https",
+			Host:   "example.com",
+			Path:   "/",
+		}
+		rootURLs = []*url.URL{urlA, urlB, urlC}
 
 		html = []byte(`<html>
 <head><title>test</title</head>
 <body><h1>TEST</h1></body>
 </html>
 `)
-		item.Response = &CrawlerResponse{Body: html}
+		item.Response = &CrawlerResponse{
+			Body:        html,
+			ContentType: HTML,
+			URL:         urlA,
+		}
 	})
 
 	AfterEach(func() {
@@ -60,7 +76,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 	})
 
 	It("generates a CrawlerMessageItem object", func() {
-		Expect(NewCrawlerMessageItem(delivery, rootURL, []string{})).ToNot(BeNil())
+		Expect(NewCrawlerMessageItem(delivery, rootURLs, []string{})).ToNot(BeNil())
+	})
+
+	It("can get the Response.Request.URL of the crawled URL", func() {
+		Expect(item.Response.URL).To(Equal(urlA))
 	})
 
 	Describe("getting and setting the Response.Body", func() {
@@ -69,7 +89,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 		})
 
 		It("can set the Response.Body of the crawled URL", func() {
-			item := NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item := NewCrawlerMessageItem(delivery, rootURLs, []string{})
 			item.Response = &CrawlerResponse{Body: []byte("foo")}
 
 			Expect(item.Response.Body).To(Equal([]byte("foo")))
@@ -78,7 +98,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 
 	It("detects when a URL is blacklisted", func() {
 		delivery = amqp.Delivery{Body: []byte("https://www.example.com/blacklisted")}
-		item := NewCrawlerMessageItem(delivery, rootURL, []string{"/blacklisted"})
+		item := NewCrawlerMessageItem(delivery, rootURLs, []string{"/blacklisted"})
 		Expect(item.IsBlacklisted()).To(BeTrue())
 	})
 
@@ -97,8 +117,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("example.com/test/url.html"))
 		})
@@ -107,8 +130,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/../../one/./two/../three"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/one/three.html"))
 		})
@@ -117,8 +143,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/test/UPPER/MiXeD"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/UPPER/MiXeD.html"))
 		})
@@ -127,8 +156,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/test/!T@e£s$t/U^R*L(){}"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/!T@e£s$t/U^R*L(){}.html"))
 		})
@@ -137,8 +169,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/test/one-two--three---"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/one-two--three---.html"))
 		})
@@ -147,8 +182,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/test/如何在香港申請英國簽證"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/如何在香港申請英國簽證.html"))
 		})
@@ -157,8 +195,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/this/url/has/a/trailing/slash/"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/this/url/has/a/trailing/slash/index.html"))
 		})
@@ -167,17 +208,23 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/index.html"))
 		})
 
 		It("omits URL query parameters", func() {
 			delivery := amqp.Delivery{Body: []byte(testURL.String() + "?foo=bar")}
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
 
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/government/organisations.html"))
 		})
@@ -185,8 +232,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 		It("omits URL fragments", func() {
 			delivery := amqp.Delivery{Body: []byte(testURL.String() + "#foo")}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
-			item.Response = &CrawlerResponse{Body: html, ContentType: HTML}
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
+			item.Response = &CrawlerResponse{
+				Body:        []byte("foo"),
+				ContentType: HTML,
+			}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/government/organisations.html"))
 		})
@@ -195,7 +245,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/things.atom"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
 			item.Response = &CrawlerResponse{Body: []byte(""), ContentType: ATOM}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/things.atom"))
@@ -205,7 +255,7 @@ var _ = Describe("CrawlerMessageItem", func() {
 			testURL.Path = "/api.json"
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
-			item = NewCrawlerMessageItem(delivery, rootURL, []string{})
+			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
 			item.Response = &CrawlerResponse{Body: []byte(""), ContentType: JSON}
 
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/api.json"))
@@ -213,6 +263,20 @@ var _ = Describe("CrawlerMessageItem", func() {
 	})
 
 	Describe("ExtractURLs", func() {
+		It("should extract all URLs that match rootURLs in a given HTML document", func() {
+			item.Response.Body = []byte(`
+                          <img src="https://assets.digital.cabinet-office.gov.uk/image.png">
+                          <a href="https://www.gov.uk/foo">Test</a>
+                          <script src="https://example.com/jq.js"></script>
+                          <script src="https://google.com/another.js"></script>
+                        `)
+
+			urls, err := item.ExtractURLs()
+
+			Expect(err).To(BeNil())
+			Expect(urls).To(HaveLen(3))
+		})
+
 		It("should return an empty array if it can't find any matching URLs", func() {
 			item.Response.Body = []byte("")
 			urls, err := item.ExtractURLs()
@@ -352,9 +416,11 @@ var _ = Describe("CrawlerMessageItem", func() {
 		})
 
 		It("removes paths that are blacklisted", func() {
-			item := NewCrawlerMessageItem(delivery, rootURL, []string{"/trade-tariff"})
+			item := NewCrawlerMessageItem(delivery, rootURLs, []string{"/trade-tariff"})
 			item.Response = &CrawlerResponse{
-				Body: []byte(`<div><a href="/foo/bar">a</a><a href="/trade-tariff">b</a></div>`),
+				Body:        []byte(`<div><a href="/foo/bar">a</a><a href="/trade-tariff">b</a></div>`),
+				ContentType: HTML,
+				URL:         urlA,
 			}
 
 			urls, err := item.ExtractURLs()

--- a/http_crawler/crawler.go
+++ b/http_crawler/crawler.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	ErrCannotCrawlURL  = errors.New("Cannot crawl URLs that don't live under the provided root URL")
+	ErrCannotCrawlURL  = errors.New("Cannot crawl URLs that don't live under the provided root URLs")
 	ErrNotFound        = errors.New("404 Not Found")
 	ErrRedirect        = errors.New("HTTP redirect encountered")
 	ErrRetryRequest5XX = errors.New("Retry request: 5XX HTTP Response returned")
@@ -31,15 +31,15 @@ type BasicAuth struct {
 }
 
 type Crawler struct {
-	RootURL *url.URL
+	RootURLs []*url.URL
 
 	basicAuth *BasicAuth
 	version   string
 }
 
-func NewCrawler(rootURL *url.URL, versionNumber string, basicAuth *BasicAuth) *Crawler {
+func NewCrawler(rootURLs []*url.URL, versionNumber string, basicAuth *BasicAuth) *Crawler {
 	return &Crawler{
-		RootURL: rootURL,
+		RootURLs: rootURLs,
 
 		basicAuth: basicAuth,
 		version:   versionNumber,
@@ -47,7 +47,7 @@ func NewCrawler(rootURL *url.URL, versionNumber string, basicAuth *BasicAuth) *C
 }
 
 func (c *Crawler) Crawl(crawlURL *url.URL) (*CrawlerResponse, error) {
-	if !strings.HasPrefix(crawlURL.Host, c.RootURL.Host) {
+	if !IsAllowedHost(crawlURL.Host, c.RootURLs) {
 		return nil, ErrCannotCrawlURL
 	}
 
@@ -91,6 +91,7 @@ func (c *Crawler) Crawl(crawlURL *url.URL) (*CrawlerResponse, error) {
 	response := &CrawlerResponse{
 		Body:        body,
 		ContentType: resp.Header.Get("Content-Type"),
+		URL:         resp.Request.URL,
 	}
 
 	return response, nil

--- a/http_crawler/crawler.go
+++ b/http_crawler/crawler.go
@@ -121,6 +121,23 @@ func contains(haystack []int, needle int) bool {
 	return false
 }
 
+func IsAllowedHost(needle string, allowedHosts []*url.URL) bool {
+	needleHost, err := HostOnly(needle)
+	if err != nil {
+		return false
+	}
+
+	for _, url := range allowedHosts {
+		h, _ := HostOnly(url.Host)
+
+		if h == needleHost {
+			return true
+		}
+	}
+
+	return false
+}
+
 // HostOnly parses out the host and removes the port (and separating colon) if
 // present.
 func HostOnly(hostport string) (string, error) {

--- a/http_crawler/crawler.go
+++ b/http_crawler/crawler.go
@@ -75,11 +75,11 @@ func (c *Crawler) Crawl(crawlURL *url.URL) (*CrawlerResponse, error) {
 	switch {
 	case resp.StatusCode == 429:
 		return nil, ErrRetryRequest429
-	case contains(Retry5XXStatusCodes(), resp.StatusCode):
+	case containsInt(Retry5XXStatusCodes(), resp.StatusCode):
 		return nil, ErrRetryRequest5XX
 	case resp.StatusCode == http.StatusNotFound:
 		return nil, ErrNotFound
-	case contains(redirectStatusCodes, resp.StatusCode):
+	case containsInt(redirectStatusCodes, resp.StatusCode):
 		return nil, ErrRedirect
 	}
 
@@ -111,7 +111,7 @@ func Retry5XXStatusCodes() []int {
 	return statusCodes
 }
 
-func contains(haystack []int, needle int) bool {
+func containsInt(haystack []int, needle int) bool {
 	for _, hay := range haystack {
 		if hay == needle {
 			return true

--- a/http_crawler/crawler.go
+++ b/http_crawler/crawler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -118,4 +119,20 @@ func contains(haystack []int, needle int) bool {
 	}
 
 	return false
+}
+
+// HostOnly parses out the host and removes the port (and separating colon) if
+// present.
+func HostOnly(hostport string) (string, error) {
+	host, _, err := net.SplitHostPort(hostport)
+
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "missing port in address") {
+			return hostport, nil
+		}
+
+		return "", err
+	}
+
+	return host, nil
 }

--- a/http_crawler/crawler_response.go
+++ b/http_crawler/crawler_response.go
@@ -2,6 +2,7 @@ package http_crawler
 
 import (
 	"mime"
+	"net/url"
 )
 
 const (
@@ -28,6 +29,7 @@ const (
 type CrawlerResponse struct {
 	Body        []byte
 	ContentType string
+	URL         *url.URL
 }
 
 func (c *CrawlerResponse) AcceptedContentType() bool {

--- a/http_crawler/crawler_response_test.go
+++ b/http_crawler/crawler_response_test.go
@@ -35,7 +35,6 @@ var _ = Describe("CrawlerResponse", func() {
 
 	Describe("ContentType", func() {
 		It("returns the error if we can't parse the content type", func() {
-			response := &CrawlerResponse{}
 			mime, err := response.ParseContentType()
 
 			Expect(mime).To(BeEmpty())

--- a/http_crawler/crawler_test.go
+++ b/http_crawler/crawler_test.go
@@ -198,4 +198,20 @@ var _ = Describe("Crawl", func() {
 			Expect(statusCodes[99]).To(Equal(599))
 		})
 	})
+
+	Describe("HostOnly", func() {
+		It("should return only the host from a host:port tuplet", func() {
+			ret, err := HostOnly("foo:8443")
+
+			Expect(ret).To(Equal("foo"))
+			Expect(err).To(BeNil())
+		})
+
+		It("should return the hostname if no port is specified", func() {
+			ret, err := HostOnly("foo")
+
+			Expect(ret).To(Equal("foo"))
+			Expect(err).To(BeNil())
+		})
+	})
 })

--- a/http_crawler/crawler_test.go
+++ b/http_crawler/crawler_test.go
@@ -25,13 +25,21 @@ func testServer(status int, body string) *httptest.Server {
 
 var _ = Describe("Crawl", func() {
 	var crawler *Crawler
+	var urlA, urlB *url.URL
 
 	BeforeEach(func() {
-		rootURL := &url.URL{
+		urlA = &url.URL{
 			Scheme: "http",
 			Host:   "127.0.0.1",
+			Path:   "/",
 		}
-		crawler = NewCrawler(rootURL, "0.0.0", nil)
+		urlB = &url.URL{
+			Scheme: "http",
+			Host:   "127.0.0.2",
+			Path:   "/",
+		}
+		rootURLs = []*url.URL{urlA, urlB}
+		crawler = NewCrawler(rootURLs, "0.0.0", nil)
 		Expect(crawler).ToNot(BeNil())
 	})
 
@@ -196,6 +204,18 @@ var _ = Describe("Crawl", func() {
 			Expect(len(statusCodes)).To(Equal(100))
 			Expect(statusCodes[0]).To(Equal(500))
 			Expect(statusCodes[99]).To(Equal(599))
+		})
+	})
+
+	Describe("IsAllowedHost", func() {
+		It("should return true if URL has allowed host", func() {
+			ret := IsAllowedHost(urlA.Host, []*url.URL{urlA})
+			Expect(ret).To(BeTrue())
+		})
+
+		It("should return false if URL host is not allowed", func() {
+			ret := IsAllowedHost(urlB.Host, []*url.URL{urlA})
+			Expect(ret).To(BeFalse())
 		})
 	})
 

--- a/workflow.go
+++ b/workflow.go
@@ -20,7 +20,7 @@ const AlreadyCrawled int = -1
 
 func ReadFromQueue(
 	inboundChannel <-chan amqp.Delivery,
-	rootURL *url.URL,
+	rootURLs []*url.URL,
 	ttlHashSet *ttl_hash_set.TTLHashSet,
 	blacklistPaths []string,
 	crawlerThreads int,
@@ -35,7 +35,7 @@ func ReadFromQueue(
 	) {
 		for item := range inbound {
 			start := time.Now()
-			message := NewCrawlerMessageItem(item, rootURL, blacklistPaths)
+			message := NewCrawlerMessageItem(item, rootURLs, blacklistPaths)
 
 			if message.IsBlacklisted() {
 				item.Ack(false)
@@ -190,8 +190,8 @@ func WriteItemToDisk(basePath string, crawlChannel <-chan *CrawlerMessageItem) <
 			}
 
 			filePath := filepath.Join(basePath, relativeFilePath)
-			basePath := filepath.Dir(filePath)
-			err = os.MkdirAll(basePath, 0755)
+			dirPath := filepath.Dir(filePath)
+			err = os.MkdirAll(dirPath, 0755)
 
 			if err != nil {
 				item.Reject(false)


### PR DESCRIPTION
We have 2 hostnames, one that we serve the site on and one which is used for assets. We'd like to crawl URLs from both hostnames and store them in separate places on disk.

---

Lots of people have worked on this but I've tried to split it out into a few small commits so it looks like it's only me. Sorry!