### PR TITLE
[#76800642] Log exceptions to an Airbrake endpoint

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -8,3 +8,4 @@ gom 'github.com/onsi/gomega', :commit => '835b5e4242c715976b98ed6bc6ece1d9c7879f
 gom 'github.com/quipo/statsd', :commit => 'c3f043b963777f5aa85795d29e6be3f6251c1beb'
 gom 'github.com/streadway/amqp', :commit => '6ffc9248c4b16699477e7411084c2402f2f0c351'
 gom 'golang.org/x/net/html', :commit => '8bc62b7ce1723e0e686c39f8fe3c5e8d03c8524c'
+gom 'github.com/tobi/airbrake-go', :commit => '5b5e269e1bc398d43f67e43dafff3414a59cd5a2'

--- a/main.go
+++ b/main.go
@@ -12,13 +12,19 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus/hooks/airbrake"
 	"github.com/alphagov/govuk_crawler_worker/http_crawler"
 	"github.com/alphagov/govuk_crawler_worker/queue"
 	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 	"github.com/alphagov/govuk_crawler_worker/util"
+	airbrake "github.com/tobi/airbrake-go"
 )
 
 var (
+	airbrakeAPIKey      = os.Getenv("AIRBRAKE_API_KEY")
+	airbrakeEnvironment = os.Getenv("AIRBRAKE_ENV")
+	airbrakeEndpoint    = os.Getenv("AIRBRAKE_ENDPOINT")
+
 	amqpAddr          = util.GetEnvDefault("AMQP_ADDRESS", "amqp://guest:guest@localhost:5672/")
 	basicAuthPassword = util.GetEnvDefault("BASIC_AUTH_PASSWORD", "")
 	basicAuthUsername = util.GetEnvDefault("BASIC_AUTH_USERNAME", "")
@@ -59,6 +65,14 @@ func init() {
 
 	if *jsonFlag {
 		log.SetFormatter(new(log.JSONFormatter))
+	}
+
+	if airbrakeAPIKey != "" && airbrake.Endpoint != "" && airbrake.Environment != "" {
+		airbrake.ApiKey = airbrakeAPIKey
+		airbrake.Environment = airbrakeEnvironment
+		airbrake.Endpoint = airbrakeEndpoint
+		log.AddHook(&logrus_airbrake.AirbrakeHook{})
+		log.Infof("Logging exceptions to Airbrake endpoint %s", airbrake.Endpoint)
 	}
 
 	if *versionFlag {


### PR DESCRIPTION
Use Logrus' hook feature to send exceptions to an Airbrake-compatible
endpoint.