### PR TITLE
[#76800642] Use new Airbrake hook

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,7 +1,7 @@
 gom 'code.google.com/p/cascadia', :commit => '5d796540e3cb93ea0556c897e6a3c7690f614d35'
 gom 'code.google.com/p/go.net/html/atom', :commit => 'eb3aa32581e642b8f84f8103124a98c82e252b4e'
 gom 'github.com/PuerkitoBio/goquery', :commit => 'ffa8a68c9f2882d21c77b65737c84e2f8690fa1f'
-gom 'github.com/Sirupsen/logrus', :commit => '965349de21e7b1e9e80b6ae02e093f1522516ef3'
+gom 'github.com/alphagov/logrus', :branch => 'add_aibrake_v2', :commit => '0fce55d0474b24634fc13d3bd2525ddc52b7ffa8'
 gom 'github.com/fzzy/radix/redis', :commit => 'acc2681fddcde19503e01e18abf7ca9b16fabcc7'
 gom 'github.com/onsi/ginkgo', :commit => '75d0cd9c7ee52e99b13e6ccfd9e58b4f92b7795e'
 gom 'github.com/onsi/gomega', :commit => '835b5e4242c715976b98ed6bc6ece1d9c7879f66'

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func init() {
 		log.SetFormatter(new(log.JSONFormatter))
 	}
 
-	if airbrakeAPIKey != "" && airbrake.Endpoint != "" && airbrake.Environment != "" {
+	if airbrakeAPIKey != "" && airbrakeEndpoint != "" && airbrakeEnvironment != "" {
 		airbrake.ApiKey = airbrakeAPIKey
 		airbrake.Environment = airbrakeEnvironment
 		airbrake.Endpoint = airbrakeEndpoint

--- a/main.go
+++ b/main.go
@@ -12,12 +12,11 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/Sirupsen/logrus/hooks/airbrake"
 	"github.com/alphagov/govuk_crawler_worker/http_crawler"
 	"github.com/alphagov/govuk_crawler_worker/queue"
 	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 	"github.com/alphagov/govuk_crawler_worker/util"
-	airbrake "github.com/tobi/airbrake-go"
+	"github.com/alphagov/logrus/hooks/airbrake2"
 )
 
 var (
@@ -68,11 +67,8 @@ func init() {
 	}
 
 	if airbrakeAPIKey != "" && airbrakeEndpoint != "" && airbrakeEnvironment != "" {
-		airbrake.ApiKey = airbrakeAPIKey
-		airbrake.Environment = airbrakeEnvironment
-		airbrake.Endpoint = airbrakeEndpoint
-		log.AddHook(&logrus_airbrake.AirbrakeHook{})
-		log.Infof("Logging exceptions to Airbrake endpoint %s", airbrake.Endpoint)
+		log.AddHook(airbrake.NewHook(airbrakeEndpoint, airbrakeAPIKey, airbrakeEnvironment))
+		log.Infof("Logging exceptions to Airbrake endpoint %s", airbrakeEndpoint)
 	}
 
 	if *versionFlag {


### PR DESCRIPTION
The previous hook used to send exceptions to Errbit's
Airbrake-compatible API was raising errors because we weren't adding an
'error' field to each log entry:

    {"endpoint":"https://errbit.preview.alphagov.co.uk","level":"warning","msg":"Exceptions sent to Airbrake must have an 'error' key with the error","source":"airbrake","time":"2015-03-09T11:20:55Z"}

I wrote an integration test for the previous hook which documents this
behaviour:
https://github.com/Sirupsen/logrus/pull/145/files#diff-b9bcfed63bb364328842ba8e05acaa26R46

The previous hook is useful if you need to pass an error type to Errbit,
but in our case we only need to send the error message. So I raised a PR
upstream to implement a new hook:
Sirupsen/logrus#146

That PR has not yet been merged upstream, so this commit swaps out the
old hook for the new one in our `alphagov/logrus` fork.