### PR TITLE
Use Travis' container-based CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,9 @@ services:
 
 script: make
 
+# Use Travis' container-based infrastructure:
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
 notifications:
   email: false


### PR DESCRIPTION
...which provides faster start times.

I also believe it's less commonly used, so may mean that our builds are
in less contention (and thus complete faster).