### PR TITLE
Add rateLimitToken parameter

### DIFF
--- a/http_crawler/crawler.go
+++ b/http_crawler/crawler.go
@@ -37,12 +37,13 @@ type Crawler struct {
 	version   string
 }
 
-func NewCrawler(rootURLs []*url.URL, versionNumber string, basicAuth *BasicAuth) *Crawler {
+func NewCrawler(rootURLs []*url.URL, versionNumber string, rateLimitToken string, basicAuth *BasicAuth) *Crawler {
 	return &Crawler{
 		RootURLs: rootURLs,
 
 		basicAuth: basicAuth,
 		version:   versionNumber,
+                rateLimitToken: rateLimitToken,
 	}
 }
 
@@ -59,6 +60,10 @@ func (c *Crawler) Crawl(crawlURL *url.URL) (*CrawlerResponse, error) {
 	if c.basicAuth != nil {
 		req.SetBasicAuth(c.basicAuth.Username, c.basicAuth.Password)
 	}
+
+        if c.rateLimitToken != nil {
+                req.Header.Set("Rate-Limit-Token", rateLimitToken)
+        }
 
 	hostname, _ := os.Hostname()
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	rootURLString     = util.GetEnvDefault("ROOT_URLS", "https://www.gov.uk/")
 	ttlExpireString   = util.GetEnvDefault("TTL_EXPIRE_TIME", "12h")
 	mirrorRoot        = os.Getenv("MIRROR_ROOT")
+        rateLimitToken    = os.Getenv("RATE_LIMIT_TOKEN")
 )
 
 const versionNumber string = "0.1.0"
@@ -114,10 +115,10 @@ func main() {
 
 	var crawler *http_crawler.Crawler
 	if basicAuthUsername != "" && basicAuthPassword != "" {
-		crawler = http_crawler.NewCrawler(rootURLs, versionNumber,
+		crawler = http_crawler.NewCrawler(rootURLs, versionNumber, rateLimitToken,
 			&http_crawler.BasicAuth{basicAuthUsername, basicAuthPassword})
 	} else {
-		crawler = http_crawler.NewCrawler(rootURLs, versionNumber, nil)
+		crawler = http_crawler.NewCrawler(rootURLs, versionNumber, rateLimitToken, nil)
 	}
 	log.Infoln("Generated crawler:", crawler)
 


### PR DESCRIPTION
We want to be able to set the "Rate-Limit-Token" parameter so our stack doesn't rate limit requests from the crawler, which may cause incorrect results being sent to our mirrors. 

Note: this is my best guess, tips from someone who knows how to code would be welcome ;)