### PR TITLE
Reject ATOM feeds

### DIFF
--- a/http_crawler/crawler_response.go
+++ b/http_crawler/crawler_response.go
@@ -39,7 +39,7 @@ func (c *CrawlerResponse) AcceptedContentType() bool {
 	}
 
 	switch mimeType {
-	case ATOM, CSS, CSV, DOCX, GIF, HTML, ICO, ICS, JAVASCRIPT,
+	case CSS, CSV, DOCX, GIF, HTML, ICO, ICS, JAVASCRIPT,
 		JPEG, JSON, ODP, ODS, ODT, PDF, PNG, XLS, XLSX:
 		return true
 	}

--- a/http_crawler/crawler_response_test.go
+++ b/http_crawler/crawler_response_test.go
@@ -24,12 +24,17 @@ var _ = Describe("CrawlerResponse", func() {
 			for _, contentType := range []string{
 				// Provide one with a charset to be sure.
 				"text/html; charset=utf-8",
-				ATOM, CSS, CSV, DOCX, GIF, HTML, ICO, ICS, JAVASCRIPT,
+				CSS, CSV, DOCX, GIF, HTML, ICO, ICS, JAVASCRIPT,
 				JPEG, JSON, ODP, ODS, ODT, PDF, PNG, XLS, XLSX,
 			} {
 				response.ContentType = contentType
 				Expect(response.AcceptedContentType()).To(BeTrue())
 			}
+		})
+
+		It("doesn't accept feeds", func() {
+			response.ContentType = ATOM
+			Expect(response.AcceptedContentType()).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
We don't want the crawler to crawl RSS or ATOM feeds because we don't want to serve old or outdated copies of feeds to feed readers when the site is offline.

It's better for feed readers to receive 5xx responses to indicate things are broken. They'll retry updating feeds later.