### PR TITLE
Add rateLimitToken parameter

### DIFF
--- a/http_crawler/crawler.go
+++ b/http_crawler/crawler.go
@@ -33,16 +33,18 @@ type BasicAuth struct {
 type Crawler struct {
 	RootURLs []*url.URL
 
-	basicAuth *BasicAuth
-	version   string
+	basicAuth      *BasicAuth
+	version        string
+	rateLimitToken string
 }
 
-func NewCrawler(rootURLs []*url.URL, versionNumber string, basicAuth *BasicAuth) *Crawler {
+func NewCrawler(rootURLs []*url.URL, versionNumber string, rateLimitToken string, basicAuth *BasicAuth) *Crawler {
 	return &Crawler{
 		RootURLs: rootURLs,
 
-		basicAuth: basicAuth,
-		version:   versionNumber,
+		basicAuth:      basicAuth,
+		version:        versionNumber,
+		rateLimitToken: rateLimitToken,
 	}
 }
 
@@ -58,6 +60,10 @@ func (c *Crawler) Crawl(crawlURL *url.URL) (*CrawlerResponse, error) {
 
 	if c.basicAuth != nil {
 		req.SetBasicAuth(c.basicAuth.Username, c.basicAuth.Password)
+	}
+
+	if c.rateLimitToken != "" {
+		req.Header.Set("Rate-Limit-Token", c.rateLimitToken)
 	}
 
 	hostname, _ := os.Hostname()

--- a/http_crawler/crawler_test.go
+++ b/http_crawler/crawler_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Crawl", func() {
 	var crawler *Crawler
 	var rootURLs []*url.URL
 	var urlA, urlB *url.URL
+	var token string
 
 	BeforeEach(func() {
 		urlA = &url.URL{
@@ -40,7 +41,8 @@ var _ = Describe("Crawl", func() {
 			Path:   "/",
 		}
 		rootURLs = []*url.URL{urlA, urlB}
-		crawler = NewCrawler(rootURLs, "0.0.0", nil)
+		token = "Ay8aix8guitai0uud4ohdeiqu0theuyeiy3Da1ool6nau0ohphaey9nai5teeDac"
+		crawler = NewCrawler(rootURLs, "0.0.0", token, nil)
 		Expect(crawler).ToNot(BeNil())
 	})
 
@@ -70,7 +72,7 @@ var _ = Describe("Crawl", func() {
 			basicAuthTestServer := httptest.NewServer(http.HandlerFunc(basic("username", "password")))
 			defer basicAuthTestServer.Close()
 
-			basicAuthCrawler := NewCrawler([]*url.URL{urlA}, "0.0.0", &BasicAuth{"username", "password"})
+			basicAuthCrawler := NewCrawler([]*url.URL{urlA}, "0.0.0", token, &BasicAuth{"username", "password"})
 
 			testURL, _ := url.Parse(basicAuthTestServer.URL)
 			response, err := basicAuthCrawler.Crawl(testURL)

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	rootURLString     = util.GetEnvDefault("ROOT_URLS", "https://www.gov.uk/")
 	ttlExpireString   = util.GetEnvDefault("TTL_EXPIRE_TIME", "12h")
 	mirrorRoot        = os.Getenv("MIRROR_ROOT")
+	rateLimitToken    = os.Getenv("RATE_LIMIT_TOKEN")
 )
 
 const versionNumber string = "0.1.0"
@@ -114,10 +115,10 @@ func main() {
 
 	var crawler *http_crawler.Crawler
 	if basicAuthUsername != "" && basicAuthPassword != "" {
-		crawler = http_crawler.NewCrawler(rootURLs, versionNumber,
+		crawler = http_crawler.NewCrawler(rootURLs, versionNumber, rateLimitToken,
 			&http_crawler.BasicAuth{basicAuthUsername, basicAuthPassword})
 	} else {
-		crawler = http_crawler.NewCrawler(rootURLs, versionNumber, nil)
+		crawler = http_crawler.NewCrawler(rootURLs, versionNumber, rateLimitToken, nil)
 	}
 	log.Infoln("Generated crawler:", crawler)
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Util", func() {
 			if netErr, ok := urlErr.Err.(*net.OpError); ok {
 				Expect(netErr.Err.(*os.SyscallError).Err).To(Equal(syscall.ECONNRESET))
 			} else {
-				Expect(urlErr).To(MatchError("EOF"))
+                                Expect(urlErr.Err).To(MatchError("EOF"))
 			}
 			Expect(resp).To(BeNil())
 		})

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Workflow", func() {
 			testURL      *url.URL
 			urlA         *url.URL
 			urlB         *url.URL
+			token        string
 		)
 
 		BeforeEach(func() {
@@ -59,6 +60,7 @@ var _ = Describe("Workflow", func() {
 				Path:   "/",
 			}
 			rootURLs = []*url.URL{urlA, urlB}
+			token = "cho1coociexei7aech8Zah1rageef2SheewaiQuilaeze1lawoobahcohtheWeik"
 
 			testURL = &url.URL{
 				Scheme: "https",
@@ -143,7 +145,7 @@ var _ = Describe("Workflow", func() {
 				urlA, _ := url.Parse("http://127.0.0.1")
 				urlB, _ := url.Parse("http://127.0.0.2")
 				rootURLs = []*url.URL{urlA, urlB}
-				crawler = NewCrawler(rootURLs, "0.0.0", nil)
+				crawler = NewCrawler(rootURLs, "0.0.0", token, nil)
 				Expect(crawler).ToNot(BeNil())
 			})
 


### PR DESCRIPTION
We want to be able to set the "Rate-Limit-Token" parameter so our stack doesn't rate limit requests from the crawler, which may cause incorrect results being sent to our mirrors.