### PR TITLE
Clean up the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,15 @@
 .PHONY: test build
 
+BINDIR ?= .
 BINARY := govuk_crawler_worker
-ORG_PATH := github.com/alphagov
-REPO_PATH := $(ORG_PATH)/govuk_crawler_worker
 
 all: test build
 
 test:
-	go test -v \
-		$(REPO_PATH) \
-		$(REPO_PATH)/http_crawler \
-		$(REPO_PATH)/queue \
-		$(REPO_PATH)/ttl_hash_set \
-		$(REPO_PATH)/util \
+	go test -v $$(go list ./... | grep -v '/vendor')
 
 build:
-	go build -o $(BINARY)
+	go build -o $(BINDIR)/$(BINARY)
 
 clean:
-	rm -rf bin $(BINARY)
+	rm -rf $(BINDIR)/$(BINARY)


### PR DESCRIPTION
Using Godep requires that we build the app from within a correctly structured [workspace](https://golang.org/doc/code.html#Workspaces).  This is primarily managed by the CI Jenkins job, and this change gives the option for placing the built binary somewhere specific.