### PR TITLE
Update /healthcheck to provide better encapsulation and more information

### DIFF
--- a/health_check.go
+++ b/health_check.go
@@ -1,129 +1,80 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
+	"github.com/alphagov/govuk_crawler_worker/healthcheck"
 
 	"github.com/alphagov/govuk_crawler_worker/queue"
 	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 )
 
-const (
-	// OK is the status of a service when it is operating correctly.
-	OK = "ok"
-	// Warning is the status of a service when it is still available but some
-	// systems may be unavailable or in an incorrect state.
-	Warning = "warning"
-	// Critical is the status of a service in a critical state.
-	Critical = "critical"
-)
-
-// Status represents the overall status of the application.
-type Status struct {
-	Status string           `json:"status"`
-	Checks map[string]Check `json:"checks,omitEmpty"`
+// NewHealthCheck creates a new healthcheck.healthCheck value with all relevant
+// checks already defined and configured.
+func NewHealthCheck(queueManager *queue.Manager, ttlHashSet *ttl_hash_set.TTLHashSet) *healthcheck.HealthCheck {
+	return healthcheck.NewHealthCheck(
+		redisChecker{ttlHashSet},
+		rabbitConsumerChecker{queueManager},
+		rabbitPublisherChecker{queueManager},
+	)
 }
 
-// Check is a single check which is performed as part of the overall system
-// status.  All individual check statuses must be `ok` for the overall system
-// status to be `ok`.
-type Check struct {
-	Name   string `json:"-"`
-	Status string `json:"status"`
+// A healthcheck.Checker that reports if the application can talk to Redis.
+type redisChecker struct {
+	ttlHashSet *ttl_hash_set.TTLHashSet
 }
 
-// HealthCheck encapsulates the external connections references that are
-// required for the application to function, and facilitates checking of the
-// status of those connections and, therefore, the overall application health.
-type HealthCheck struct {
-	port         string
-	queueManager *queue.Manager
-	ttlHashSet   *ttl_hash_set.TTLHashSet
+func (r redisChecker) Name() string {
+	return "redis"
 }
 
-// NewHealthCheck creates a new HealthCheck value.
-func NewHealthCheck(queueManager *queue.Manager, ttlHashSet *ttl_hash_set.TTLHashSet) *HealthCheck {
-	return &HealthCheck{
-		queueManager: queueManager,
-		ttlHashSet:   ttlHashSet,
-	}
-}
-
-// Status returns the overall health status of the application.
-func (h *HealthCheck) Status() Status {
-	checks := map[string]Check{
-		"redis":              h.redisCheck(),
-		"rabbitmq_consumer":  h.rabbitConsumerCheck(),
-		"rabbitmq_publisher": h.rabbitPublisherCheck(),
-	}
-
-	status := OK
-	for _, c := range checks {
-		if c.Status != OK {
-			status = Critical
-		}
-	}
-
-	return Status{
-		Status: status,
-		Checks: checks,
-	}
-}
-
-func (h *HealthCheck) redisCheck() Check {
-	pong, err := h.ttlHashSet.Ping()
-	status := Critical
+func (r redisChecker) Check() (healthcheck.StatusEnum, error) {
+	pong, err := r.ttlHashSet.Ping()
+	status := healthcheck.Critical
 
 	if err == nil && pong == "PONG" {
-		status = OK
+		status = healthcheck.OK
 	}
 
-	return Check{
-		Name:   "redis",
-		Status: status,
-	}
+	return status, err
 }
 
-func (h *HealthCheck) rabbitConsumerCheck() Check {
-	consumerInspect, err := h.queueManager.Consumer.Channel.QueueInspect(h.queueManager.QueueName)
-	status := Critical
-
-	if err == nil && consumerInspect.Name == h.queueManager.QueueName {
-		status = OK
-	}
-
-	return Check{
-		Name:   "rabbitmq_consumer",
-		Status: status,
-	}
+// A healthcheck.Checker that reports if the application can consume messages
+// from a RabbitMQ queue.
+type rabbitConsumerChecker struct {
+	queueManager *queue.Manager
 }
 
-func (h *HealthCheck) rabbitPublisherCheck() Check {
-	publisherInspect, err := h.queueManager.Producer.Channel.QueueInspect(h.queueManager.QueueName)
-	status := Critical
-
-	if err == nil && publisherInspect.Name == h.queueManager.QueueName {
-		status = OK
-	}
-
-	return Check{
-		Name:   "rabbitmq_publisher",
-		Status: status,
-	}
+func (r rabbitConsumerChecker) Name() string {
+	return "rabbitmq_consumer"
 }
 
-// HTTPHandler is a handler function for serving up the application healthcheck
-// status.
-func (h *HealthCheck) HTTPHandler() func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		status := h.Status()
-		encoder := json.NewEncoder(w)
+func (r rabbitConsumerChecker) Check() (healthcheck.StatusEnum, error) {
+	consumerInspect, err := r.queueManager.Consumer.Channel.QueueInspect(r.queueManager.QueueName)
+	status := healthcheck.Critical
 
-		err := encoder.Encode(&status)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("Cannot encode response data: %v", err),
-				http.StatusInternalServerError)
-		}
+	if err == nil && consumerInspect.Name == r.queueManager.QueueName {
+		status = healthcheck.OK
 	}
+
+	return status, err
+}
+
+// A healthcheck.Checker that reports if the application can publisher messages
+// to a RabbitMQ exchange.
+type rabbitPublisherChecker struct {
+	queueManager *queue.Manager
+}
+
+func (r rabbitPublisherChecker) Name() string {
+	return "rabbitmq_publisher"
+}
+
+func (r rabbitPublisherChecker) Check() (healthcheck.StatusEnum, error) {
+	publisherInspect, err := r.queueManager.Producer.Channel.QueueInspect(r.queueManager.QueueName)
+	status := healthcheck.Critical
+
+	if err == nil && publisherInspect.Name == r.queueManager.QueueName {
+		status = healthcheck.OK
+	}
+
+	return status, err
 }

--- a/health_check.go
+++ b/health_check.go
@@ -9,17 +9,40 @@ import (
 	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 )
 
+const (
+	// OK is the status of a service when it is operating correctly.
+	OK = "ok"
+	// Warning is the status of a service when it is still available but some
+	// systems may be unavailable or in an incorrect state.
+	Warning = "warning"
+	// Critical is the status of a service in a critical state.
+	Critical = "critical"
+)
+
+// Status represents the overall status of the application.
 type Status struct {
-	AMQP  bool `json:"amqp"`
-	Redis bool `json:"redis"`
+	Status string           `json:"status"`
+	Checks map[string]Check `json:"checks,omitEmpty"`
 }
 
+// Check is a single check which is performed as part of the overall system
+// status.  All individual check statuses must be `ok` for the overall system
+// status to be `ok`.
+type Check struct {
+	Name   string `json:"-"`
+	Status string `json:"status"`
+}
+
+// HealthCheck encapsulates the external connections references that are
+// required for the application to function, and facilitates checking of the
+// status of those connections and, therefore, the overall application health.
 type HealthCheck struct {
 	port         string
 	queueManager *queue.Manager
 	ttlHashSet   *ttl_hash_set.TTLHashSet
 }
 
+// NewHealthCheck creates a new HealthCheck value.
 func NewHealthCheck(queueManager *queue.Manager, ttlHashSet *ttl_hash_set.TTLHashSet) *HealthCheck {
 	return &HealthCheck{
 		queueManager: queueManager,
@@ -27,30 +50,71 @@ func NewHealthCheck(queueManager *queue.Manager, ttlHashSet *ttl_hash_set.TTLHas
 	}
 }
 
-func (h *HealthCheck) Status() *Status {
-	var consumerStatus, publisherStatus, redisStatus bool
-
-	pong, err := h.ttlHashSet.Ping()
-	if err == nil && pong == "PONG" {
-		redisStatus = true
+// Status returns the overall health status of the application.
+func (h *HealthCheck) Status() Status {
+	checks := map[string]Check{
+		"redis":              h.redisCheck(),
+		"rabbitmq_consumer":  h.rabbitConsumerCheck(),
+		"rabbitmq_publisher": h.rabbitPublisherCheck(),
 	}
 
-	consumerInspect, err := h.queueManager.Consumer.Channel.QueueInspect(h.queueManager.QueueName)
-	if err == nil && consumerInspect.Name == h.queueManager.QueueName {
-		consumerStatus = true
+	status := OK
+	for _, c := range checks {
+		if c.Status != OK {
+			status = Critical
+		}
 	}
 
-	publisherInspect, err := h.queueManager.Producer.Channel.QueueInspect(h.queueManager.QueueName)
-	if err == nil && publisherInspect.Name == h.queueManager.QueueName {
-		publisherStatus = true
-	}
-
-	return &Status{
-		AMQP:  (consumerStatus && publisherStatus),
-		Redis: redisStatus,
+	return Status{
+		Status: status,
+		Checks: checks,
 	}
 }
 
+func (h *HealthCheck) redisCheck() Check {
+	pong, err := h.ttlHashSet.Ping()
+	status := Critical
+
+	if err == nil && pong == "PONG" {
+		status = OK
+	}
+
+	return Check{
+		Name:   "redis",
+		Status: status,
+	}
+}
+
+func (h *HealthCheck) rabbitConsumerCheck() Check {
+	consumerInspect, err := h.queueManager.Consumer.Channel.QueueInspect(h.queueManager.QueueName)
+	status := Critical
+
+	if err == nil && consumerInspect.Name == h.queueManager.QueueName {
+		status = OK
+	}
+
+	return Check{
+		Name:   "rabbitmq_consumer",
+		Status: status,
+	}
+}
+
+func (h *HealthCheck) rabbitPublisherCheck() Check {
+	publisherInspect, err := h.queueManager.Producer.Channel.QueueInspect(h.queueManager.QueueName)
+	status := Critical
+
+	if err == nil && publisherInspect.Name == h.queueManager.QueueName {
+		status = OK
+	}
+
+	return Check{
+		Name:   "rabbitmq_publisher",
+		Status: status,
+	}
+}
+
+// HTTPHandler is a handler function for serving up the application healthcheck
+// status.
 func (h *HealthCheck) HTTPHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		status := h.Status()

--- a/health_check.go
+++ b/health_check.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/alphagov/govuk_crawler_worker/healthcheck"
-
 	"github.com/alphagov/govuk_crawler_worker/queue"
 	"github.com/alphagov/govuk_crawler_worker/ttl_hash_set"
 )

--- a/health_check_test.go
+++ b/health_check_test.go
@@ -90,12 +90,12 @@ var _ = Describe("HealthCheck", func() {
 			queueManager.Close()
 		})
 
-		It("has a successful overall system status", func() {
+		It("reports that the health of the system is OK", func() {
 			healthCheck := NewHealthCheck(queueManager, ttlHashSet)
 			Expect(healthCheck.Status().Status).To(Equal(healthcheck.OK))
 		})
 
-		It("has successful statuses for each individual check", func() {
+		It("reports that the health of each check is OK", func() {
 			healthCheck := NewHealthCheck(queueManager, ttlHashSet)
 			for _, check := range healthCheck.Status().Checks {
 				Expect(check.Status).To(Equal(healthcheck.OK))

--- a/healthcheck/health_check.go
+++ b/healthcheck/health_check.go
@@ -30,7 +30,7 @@
 // `critical` status.  The same timeout length applies to each individual
 // check.
 //
-// A you require a custom timeout length, you can either set the timeout after
+// If you require a custom timeout length, you can either set the timeout after
 // calling NewHealthCheck, or create a HealthCheck value manually.
 //
 //   timeout := time.Minute

--- a/healthcheck/health_check.go
+++ b/healthcheck/health_check.go
@@ -1,0 +1,125 @@
+package healthcheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// StatusEnum is a enum type for the valid states of a service.
+type StatusEnum int
+
+const (
+	// OK is the status of a service when it is operating correctly.
+	OK StatusEnum = iota
+	// Warning is the status of a service when it is still available but some
+	// systems may be unavailable or in an incorrect state.
+	Warning
+	// Critical is the status of a service in a critical state.
+	Critical
+)
+
+// statusValues is a mapping of StatusEnum values to their human-readable form.
+var statusValues = map[StatusEnum]string{
+	OK:       "ok",
+	Warning:  "warning",
+	Critical: "critical",
+}
+
+// String converts a numeric status identifer to a human-readable
+// representation, or returns `unknown` if the status can't be identified.
+func (s StatusEnum) String() string {
+	if status, ok := statusValues[s]; ok {
+		return status
+	}
+	return "unknown"
+}
+
+// MarshalJSON is a concrete implementation of the json.Marshaler interface
+// which allows StatusEnum values to be converted to their human-readable
+// representation when serialising to JSON.
+func (s StatusEnum) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+// Checker is the interface to which all individual status checks must satisfy.
+type Checker interface {
+	Name() string
+	Check() (StatusEnum, error)
+}
+
+// Status represents the overall status of the application.
+type Status struct {
+	Status StatusEnum       `json:"status"`
+	Checks map[string]Check `json:"checks,omitEmpty"`
+}
+
+// Check is a single check which is performed as part of the overall system
+// status.  All individual check statuses must be `ok` for the overall system
+// status to be `ok`.
+type Check struct {
+	Status  StatusEnum `json:"status"`
+	Message string     `json:"message,omitempty"`
+}
+
+// HealthCheck encapsulates and performs checks which are used to identify the
+// health of a the application.
+type HealthCheck struct {
+	Checkers []Checker
+}
+
+// NewHealthCheck is a helper function for quickly creating a new HealthCheck
+// value with the appropriate checkers in place.
+func NewHealthCheck(checkers ...Checker) *HealthCheck {
+	return &HealthCheck{Checkers: checkers}
+}
+
+// Status runs all checks and responds with the individual statuses for those
+// checks, as well as an overall status.
+//
+// * If all checks are `ok`, then the overall status will also be `ok`.
+// * If one or more checks are in a `warning` state, and no checks are in a
+//   `critical` state, then the overall status will be `warning`.
+// * If one or more checks are in a `critical` state, the overall state will be
+//   `critical`.
+func (h *HealthCheck) Status() Status {
+	checked := map[string]Check{}
+	status := OK
+
+	for _, checker := range h.Checkers {
+		c := Check{}
+
+		var err error
+		c.Status, err = checker.Check()
+
+		if err != nil {
+			c.Message = err.Error()
+		}
+
+		if status < c.Status {
+			status = c.Status
+		}
+
+		checked[checker.Name()] = c
+	}
+
+	return Status{
+		Status: status,
+		Checks: checked,
+	}
+}
+
+// HTTPHandler is a handler function for serving up the application healthcheck
+// status via HTTP.
+func (h *HealthCheck) HTTPHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		status := h.Status()
+		encoder := json.NewEncoder(w)
+
+		err := encoder.Encode(status)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Cannot encode response data: %v", err),
+				http.StatusInternalServerError)
+		}
+	}
+}

--- a/healthcheck/health_check_test.go
+++ b/healthcheck/health_check_test.go
@@ -92,7 +92,10 @@ var _ = Describe("HealthCheck", func() {
 		hc := healthcheck.NewHealthCheck(okChecker{}, criticalChecker{})
 		w := httptest.NewRecorder()
 		hc.HTTPHandler()(w, nil)
-		Expect(strings.TrimSpace(w.Body.String())).To(Equal(`{"status":"critical","checks":{"critical":{"status":"critical","message":"A critical failure"},"ok":{"status":"ok"}}}`))
+		Expect(strings.TrimSpace(w.Body.String())).To(Equal(
+			`{"status":"critical","checks":{` +
+				`"critical":{"status":"critical","message":"A critical failure"},` +
+				`"ok":{"status":"ok"}}}`))
 	})
 })
 

--- a/healthcheck/health_check_test.go
+++ b/healthcheck/health_check_test.go
@@ -1,0 +1,107 @@
+package healthcheck_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alphagov/govuk_crawler_worker/healthcheck"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HealthCheck", func() {
+	It("gives an OK status with zero checks", func() {
+		hc := healthcheck.NewHealthCheck()
+		Expect(hc.Status().Status).To(Equal(healthcheck.OK))
+	})
+
+	It("gives an OK status with multiple checks that are all OK", func() {
+		hc := healthcheck.NewHealthCheck(okChecker{}, okChecker{}, okChecker{})
+		Expect(hc.Status().Status).To(Equal(healthcheck.OK))
+	})
+
+	It("gives a Warning status with one check that is a Warning", func() {
+		hc := healthcheck.NewHealthCheck(warningChecker{})
+		Expect(hc.Status().Status).To(Equal(healthcheck.Warning))
+	})
+
+	It("gives a Warning status when at least one check is a Warning", func() {
+		hc := healthcheck.NewHealthCheck(okChecker{}, warningChecker{}, okChecker{})
+		Expect(hc.Status().Status).To(Equal(healthcheck.Warning))
+	})
+
+	It("gives a Critical status with one check that is Critical", func() {
+		hc := healthcheck.NewHealthCheck(criticalChecker{})
+		Expect(hc.Status().Status).To(Equal(healthcheck.Critical))
+	})
+
+	It("gives a Critical status when at least one check is Critical", func() {
+		hc := healthcheck.NewHealthCheck(warningChecker{}, criticalChecker{}, okChecker{})
+		Expect(hc.Status().Status).To(Equal(healthcheck.Critical))
+	})
+
+	It("gives correct individual statuses for each check", func() {
+		hc := healthcheck.NewHealthCheck(okChecker{}, warningChecker{}, criticalChecker{})
+		checks := hc.Status().Checks
+
+		Expect(checks["ok"].Status).To(Equal(healthcheck.OK))
+		Expect(checks["warning"].Status).To(Equal(healthcheck.Warning))
+		Expect(checks["critical"].Status).To(Equal(healthcheck.Critical))
+	})
+
+	It("has the correct message for each check", func() {
+		hc := healthcheck.NewHealthCheck(okChecker{}, warningChecker{}, criticalChecker{})
+		checks := hc.Status().Checks
+
+		Expect(checks["ok"].Message).To(Equal(""))
+		Expect(checks["warning"].Message).To(Equal("A warning"))
+		Expect(checks["critical"].Message).To(Equal("A critical failure"))
+	})
+
+	It("provides an HTTP handler function", func() {
+		hc := healthcheck.NewHealthCheck(okChecker{})
+		w := httptest.NewRecorder()
+		hc.HTTPHandler()(w, nil)
+		Expect(w.Code).To(Equal(http.StatusOK))
+	})
+
+	It("correctly marshalls to JSON", func() {
+		hc := healthcheck.NewHealthCheck(okChecker{}, criticalChecker{})
+		w := httptest.NewRecorder()
+		hc.HTTPHandler()(w, nil)
+		Expect(strings.TrimSpace(w.Body.String())).To(Equal(`{"status":"critical","checks":{"critical":{"status":"critical","message":"A critical failure"},"ok":{"status":"ok"}}}`))
+	})
+})
+
+func TestHealthCheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Health Check Suite")
+}
+
+// A checker that already returns `ok`
+type okChecker struct{}
+
+func (okChecker) Name() string { return "ok" }
+func (okChecker) Check() (healthcheck.StatusEnum, error) {
+	return healthcheck.OK, nil
+}
+
+// A checker that already returns `warning`
+type warningChecker struct{}
+
+func (warningChecker) Name() string { return "warning" }
+func (warningChecker) Check() (healthcheck.StatusEnum, error) {
+	return healthcheck.Warning, errors.New("A warning")
+}
+
+// A checker that already returns `critical`
+type criticalChecker struct{}
+
+func (criticalChecker) Name() string { return "critical" }
+func (criticalChecker) Check() (healthcheck.StatusEnum, error) {
+	return healthcheck.Critical, errors.New("A critical failure")
+}

--- a/healthcheck/health_check_test.go
+++ b/healthcheck/health_check_test.go
@@ -75,6 +75,12 @@ var _ = Describe("HealthCheck", func() {
 		Expect(hc.Status().Checks["ok"].Message).To(Equal("Check timed out"))
 	})
 
+	It("doesn't apply a timeout with a zero duration", func() {
+		hc := healthcheck.NewHealthCheck(okChecker{sleep: time.Millisecond * 10})
+		hc.Timeout = 0
+		Expect(hc.Status().Status).To(Equal(healthcheck.OK))
+	})
+
 	It("provides an HTTP handler function", func() {
 		hc := healthcheck.NewHealthCheck(okChecker{})
 		w := httptest.NewRecorder()


### PR DESCRIPTION
The original trigger for this was that this healtcheck was failing to return on integration, so we needed some way of identifying which check was blocking.  In doing this, I've also taken the opportunity to better encapsulate the process of health-checking.

* A new `healthcheck` package has been created which encapsulates all the generic healthchecking behaviour such as registering and running checks, serialisation of responses, and exposing an HTTPHandler func.
* All checks are now performed in parallel, and with an optional timeout (defaulting to 1 second) on each so if a check takes longer than this
* The individual checks for this application (Redis, RabbitMQ producer, and RabbitMQ consumer) are now individual types which satisfy the new `healthcheck.Checker` interface.
* The output format of the status JSON through the HTTPHandler func has been updated to be more consistent with that of our other apps (an overall status, and a hash of individual checks).

Now the generic healthcheck logic has been extracted to a separate package, we should look to implement it in other apps.  Both [alphagov/router](https://github.com/alphagov/router/blob/4456a3fa/router_api.go#L43-L51) and [alphagov/metadata-api](https://github.com/alphagov/metadata-api/blob/a9ec2f1d/main.go#L42-L44) have very naïve healthchecks that could do with being updated to add additional checks and be formatted more consistently.