### PR TITLE
Fixup some go version things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: go
 
 go:
-  - 1.7
-
-before_install:
-  - go get github.com/mattn/gom
+  - 1.7.1
 
 services:
   - rabbitmq

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ from a message queue and crawl them, saving the output to disk.
 
 To run this worker you will need:
 
- - Go 1.4
+ - Go 1.7.1
  - [RabbitMQ](https://www.rabbitmq.com/)
  - [Redis](http://redis.io/)
 


### PR DESCRIPTION
This tidies up a few old version and `gom` references. We're on 1.7.1 now and don't use `gom`.