### PR TITLE
Stop decoding URI's before requesting them.

### DIFF
--- a/crawler_message_item.go
+++ b/crawler_message_item.go
@@ -42,7 +42,11 @@ func (c *CrawlerMessageItem) RelativeFilePath() (string, error) {
 		return "", err
 	}
 
-	filePath = urlParts.Path
+	filePath, err = url.QueryUnescape(urlParts.Path)
+	if err != nil {
+		return "", err
+	}
+
 	host := strings.SplitN(urlParts.Host, ":", 2)[0]
 
 	contentType, err := c.Response.ParseContentType()
@@ -219,8 +223,7 @@ func findHrefsByElementAttribute(
 
 	document.Find(element).Each(func(_ int, element *goquery.Selection) {
 		href, _ := element.Attr(attr)
-		unescapedHref, _ := url.QueryUnescape(href)
-		trimmedHref := strings.TrimSpace(unescapedHref)
+		trimmedHref := strings.TrimSpace(href)
 		hrefs = append(hrefs, trimmedHref)
 	})
 

--- a/crawler_message_item_test.go
+++ b/crawler_message_item_test.go
@@ -178,8 +178,8 @@ var _ = Describe("CrawlerMessageItem", func() {
 			Expect(item.RelativeFilePath()).To(Equal("www.gov.uk/test/one-two--three---.html"))
 		})
 
-		It("preserves non-latin chars and not URL encode them", func() {
-			testURL.Path = "/test/如何在香港申請英國簽證"
+		It("unencodes non-latin chars and does not URL encode them", func() {
+			testURL.Path = url.QueryEscape("/test/如何在香港申請英國簽證")
 			delivery = amqp.Delivery{Body: []byte(testURL.String())}
 
 			item = NewCrawlerMessageItem(delivery, rootURLs, []string{})
@@ -370,20 +370,6 @@ var _ = Describe("CrawlerMessageItem", func() {
 
 			Expect(err).To(BeNil())
 			Expect(urls).To(BeEmpty())
-		})
-
-		It("will unescape URLs", func() {
-			item.Response.Body = []byte(`<div><a href="https://www.gov.uk/bar%20"></a></div>`)
-			expectedURL := &url.URL{
-				Scheme: "https",
-				Host:   "www.gov.uk",
-				Path:   "/bar",
-			}
-
-			urls, err := item.ExtractURLs()
-
-			Expect(err).To(BeNil())
-			Expect(urls).To(ContainElement(expectedURL))
 		})
 
 		It("should extract relative URLs", func() {


### PR DESCRIPTION
This is converting valid URI's into invalid ones by introducing UTF-8
characters into them.

This changes the behaviour so that we request valid URI's and then we
decode them when the files are saved to disk.

The prompt for this change was many (~4000 a day) errors logged in Whitehall
that originated from UTF-8 requests and Ruby Unicorns inconsistent
handling of them. See https://github.com/alphagov/slimmer/pull/182 for
more info.