### PR TITLE
Add new build tag to display name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,8 @@ node {
         stage("Push binary to S3") {
           target_tag = govuk.getNewStyleReleaseTag()
           govuk.uploadArtefactToS3('govuk_crawler_worker', "s3://govuk-integration-artefact/govuk_crawler_worker/${target_tag}/govuk_crawler_worker")
+          echo "Uploaded to S3 with tag: ${target_tag}."
+          currentBuild.displayName = "#${env.BUILD_NUMBER}:${target_tag}"
         }
       }
     }


### PR DESCRIPTION
Previously the new style build tag (timestamp + SHA) was only available
by viewing the build logs. This updates the display name to contain it,
as well as the normal build number.

This means that regardless of which method is being used for deployments
both can be accessed.