### PR TITLE
Push artifact to S3 as release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,8 +37,13 @@ node {
       if (env.BRANCH_NAME == 'master') {
         stage("Push binary to S3") {
           target_tag = govuk.getNewStyleReleaseTag()
+
           govuk.uploadArtefactToS3('govuk_crawler_worker', "s3://govuk-integration-artefact/govuk_crawler_worker/${target_tag}/govuk_crawler_worker")
           echo "Uploaded to S3 with tag: ${target_tag}."
+
+          govuk.uploadArtefactToS3('govuk_crawler_worker', "s3://govuk-integration-artefact/govuk_crawler_worker/release/govuk_crawler_worker")
+          echo "Uploaded to S3 with tag: release."
+
           currentBuild.displayName = "#${env.BUILD_NUMBER}:${target_tag}"
         }
       }


### PR DESCRIPTION
This allow the CAP deployment script to pull the file from S3 without need to
worry about the exact build number which is being deployed.

https://trello.com/c/JHcwDJc0/81-compress-rummager-data-in-sidekiq-when-updating-pageviews