### PR TITLE
Revert to standard build numbering

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,10 +36,9 @@ node {
 
       if (env.BRANCH_NAME == 'master') {
         stage("Push binary to S3") {
-          target_tag = govuk.getNewStyleReleaseTag()
-          govuk.uploadArtefactToS3('govuk_crawler_worker', "s3://govuk-integration-artefact/govuk_crawler_worker/${target_tag}/govuk_crawler_worker")
-          echo "Uploaded to S3 with tag: ${target_tag}."
-          currentBuild.displayName = "#${env.BUILD_NUMBER}:${target_tag}"
+          govuk.uploadArtefactToS3('govuk_crawler_worker', "s3://govuk-integration-artefact/govuk_crawler_worker/release_#${env.BUILD_NUMBER}/govuk_crawler_worker")
+          echo "Uploaded to S3 with tag: release_#${env.BUILD_NUMBER}."
+          currentBuild.displayName = "#${env.BUILD_NUMBER}:release_#${env.BUILD_NUMBER}"
         }
       }
     }
@@ -50,7 +49,7 @@ node {
       }
 
       stage("Deploy") {
-        govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+        govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER, 'deploy')
       }
     }
 


### PR DESCRIPTION
This means the CAP deployment using S4 will be able to find the file using the
standard release tabgging.

https://trello.com/c/brHYjFnG/83-mirrorer-queue-duplication