### PR TITLE
Reduce redis memory footprint

### DIFF
--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -38,7 +38,7 @@ var _ = Describe("HealthCheck", func() {
 		queueManager.Consumer.HandleChannelClose = func(_ string) {}
 		queueManager.Producer.HandleChannelClose = func(_ string) {}
 
-		ttlHashSet, ttlHashSetErr := ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour)
+		ttlHashSet, ttlHashSetErr := ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour, time.Minute)
 		Expect(ttlHashSetErr).To(BeNil())
 
 		deleted, err := queueManager.Consumer.Channel.QueueDelete(queueName, false, false, true)
@@ -72,7 +72,7 @@ var _ = Describe("HealthCheck", func() {
 			queueManager.Consumer.HandleChannelClose = func(_ string) {}
 			queueManager.Producer.HandleChannelClose = func(_ string) {}
 
-			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour)
+			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour, time.Minute)
 			Expect(ttlHashSetErr).To(BeNil())
 		})
 
@@ -112,7 +112,7 @@ var _ = Describe("HealthCheck", func() {
 			queueManager.Consumer.HandleChannelClose = func(_ string) {}
 			queueManager.Producer.HandleChannelClose = func(_ string) {}
 
-			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour)
+			ttlHashSet, ttlHashSetErr = ttl_hash_set.NewTTLHashSet(prefix, redisAddr, time.Hour, time.Minute)
 			Expect(ttlHashSetErr).To(BeNil())
 		})
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var (
 	maxCrawlRetries   = util.GetEnvDefault("MAX_CRAWL_RETRIES", "4")
 	queueName         = util.GetEnvDefault("AMQP_MESSAGE_QUEUE", "govuk_crawler_queue")
 	redisAddr         = util.GetEnvDefault("REDIS_ADDRESS", "127.0.0.1:6379")
-	redisKeyPrefix    = util.GetEnvDefault("REDIS_KEY_PREFIX", "govuk_crawler_worker")
+	redisKeyPrefix    = util.GetEnvDefault("REDIS_KEY_PREFIX", "gcw")
 	rootURLs          []*url.URL
 	rootURLString     = util.GetEnvDefault("ROOT_URLS", "https://www.gov.uk/")
 	ttlExpireString   = util.GetEnvDefault("TTL_EXPIRE_TIME", "12h")

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 	rootURLs          []*url.URL
 	rootURLString     = util.GetEnvDefault("ROOT_URLS", "https://www.gov.uk/")
 	ttlExpireString   = util.GetEnvDefault("TTL_EXPIRE_TIME", "12h")
+	ttlExtendString   = util.GetEnvDefault("TTL_EXTEND_TIME", "15m")
 	mirrorRoot        = os.Getenv("MIRROR_ROOT")
 	rateLimitToken    = os.Getenv("RATE_LIMIT_TOKEN")
 )
@@ -90,7 +91,12 @@ func main() {
 		log.Fatalln("Couldn't parse TTL_EXPIRE_TIME:", ttlExpireString)
 	}
 
-	ttlHashSet, err := ttl_hash_set.NewTTLHashSet(redisKeyPrefix, redisAddr, ttlExpireTime)
+	ttlExtendTime, err := time.ParseDuration(ttlExtendString)
+	if err != nil {
+		log.Fatalln("Couldn't parse TTL_EXTEND_TIME:", ttlExtendString)
+	}
+
+	ttlHashSet, err := ttl_hash_set.NewTTLHashSet(redisKeyPrefix, redisAddr, ttlExpireTime, ttlExtendTime)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/ttl_hash_set/ttl_hash_set.go
+++ b/ttl_hash_set/ttl_hash_set.go
@@ -36,9 +36,10 @@ type TTLHashSet struct {
 	prefix        string
 	rcMutex       ReconnectMutex
 	ttlExpiryTime time.Duration
+	ttlExtendTime time.Duration
 }
 
-func NewTTLHashSet(prefix string, address string, ttlExpiryTime time.Duration) (*TTLHashSet, error) {
+func NewTTLHashSet(prefix string, address string, ttlExpiryTime time.Duration, ttlExtendTime time.Duration) (*TTLHashSet, error) {
 	client, err := redis.Dial("tcp", address)
 	if err != nil {
 		return nil, err
@@ -49,6 +50,7 @@ func NewTTLHashSet(prefix string, address string, ttlExpiryTime time.Duration) (
 		client:        client,
 		prefix:        prefix,
 		ttlExpiryTime: ttlExpiryTime,
+		ttlExtendTime: ttlExtendTime,
 	}, nil
 }
 
@@ -84,6 +86,33 @@ func (t *TTLHashSet) Set(key string, val int) error {
 	t.mutex.Lock()
 	_, err := t.client.Cmd("SETEX", localKey, t.ttlExpiryTime.Seconds(), val).Bool()
 	t.mutex.Unlock()
+
+	if err != nil {
+		t.reconnectIfIOError(err)
+	}
+
+	return err
+}
+
+func (t *TTLHashSet) SetOrExtend(key string, val int) error {
+	localKey := prefixKey(t.prefix, key)
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	ttl, err := t.client.Cmd("TTL", localKey).Int()
+	if err != nil || ttl == -2 { // key not present
+		ttl = 0
+	}
+
+	timeout := float64(ttl) + t.ttlExtendTime.Seconds()
+
+	if timeout > t.ttlExpiryTime.Seconds() {
+		timeout = t.ttlExpiryTime.Seconds()
+	}
+
+	// Use pipelining to set the key and set expiry in one go.
+	_, err = t.client.Cmd("SETEX", localKey, timeout, val).Bool()
 
 	if err != nil {
 		t.reconnectIfIOError(err)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Workflow", func() {
 				Host:   "www.gov.uk",
 			}
 
-			ttlHashSet, ttlHashSetErr = NewTTLHashSet(prefix, redisAddr, time.Hour)
+			ttlHashSet, ttlHashSetErr = NewTTLHashSet(prefix, redisAddr, time.Hour, time.Minute)
 			Expect(ttlHashSetErr).To(BeNil())
 
 			queueManager, queueManagerErr = NewManager(


### PR DESCRIPTION
Now that we are storing the keys in redis we are running into memory issues on
the machine.

We want to stop duplicates from existing in RabbitMQ and we will do this using
redis to store URLs which exist in RabbitMQ, however not all URL are created
equal, so instead of storing all URLs in redis we will try and keep track of
the most common URLs, stopping them being duplicated in rabbit. This means
we will reintroduce some duplication in rabbit, but allow us to manage our redis
memory usage.

We will do this by reducing the redis TTL, if the URL is encountered a again
before the TTL expires, the TTL will be extended, if it only encounters the URL
again after the TTL has expired the url will be inserted into rabbit a 2nd time
and a new TTL set.