### PR TITLE
Ignore URL’s with query params

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 	dontQuit := make(chan struct{})
 
 	var acknowledgeChan, crawlChan, persistChan, parseChan <-chan *CrawlerMessageItem
-	publishChan := make(<-chan string, 100)
+	publishChan := make(<-chan *url.URL, 100)
 
 	var crawlerThreadsInt int
 	crawlerThreadsInt, err = strconv.Atoi(crawlerThreads)


### PR DESCRIPTION
The files are saved without query params as such processing URLs that contain them results in a the rendered view being what was generated from the last processed set of query params. This can lead to incorrect and inconsistent results.

https://trello.com/c/BBrR21kl/111-ignore-query-params-when-running-mirrorer