### PR TITLE
Process URL that have a page param

### DIFF
--- a/crawler_message_item.go
+++ b/crawler_message_item.go
@@ -34,6 +34,12 @@ func (c *CrawlerMessageItem) URL() string {
 	return string(c.Body)
 }
 
+func (c *CrawlerMessageItem) hasParams() bool {
+	urlParts, err := url.Parse(c.URL())
+
+	return (err != nil || urlParts.RawQuery != "")
+}
+
 func (c *CrawlerMessageItem) RelativeFilePath() (string, error) {
 	var filePath string
 


### PR DESCRIPTION
We have added this to allow the crawler to follow through multiple pages in the
search results, this should help ensure that we archive every page on the site.

We ensure that URL's with a page command are crawled, however we do not write
them to disk.

https://trello.com/c/5Le8O6cb/120-crawl-pages-with-page-param