### PR TITLE
Follow redirects and create a trail for static serving

### DIFF
--- a/http_crawler/crawler_test.go
+++ b/http_crawler/crawler_test.go
@@ -110,9 +110,10 @@ var _ = Describe("Crawl", func() {
 			defer ts.Close()
 
 			testURL, _ := url.Parse(ts.URL)
-			_, err := crawler.Crawl(testURL)
+			response, err := crawler.Crawl(testURL)
 
-			Expect(err).To(Equal(errors.New("HTTP redirect encountered")))
+			Expect(err).To(BeNil())
+			Expect(string(response.Body)).Should(MatchRegexp("Redirecting you to <a href=\"/redirect\">/redirect</a>"))
 		})
 
 		It("returns an error when server returns a 404", func() {

--- a/workflow.go
+++ b/workflow.go
@@ -116,16 +116,6 @@ func CrawlURL(
 					item.Reject(true)
 
 					log.Warningln("Couldn't crawl (requeueing):", u.String(), err)
-				case http_crawler.ErrRedirect:
-
-					err = ttlHashSet.Set(item.URL(), ReadyToEnqueue)
-					if err != nil {
-						log.Errorln("Couldn't mark item as already crawled:", item.URL(), err)
-					}
-
-					item.Reject(false)
-					// log at INFO because redirect URLs are not a concern
-					log.Debugln("Couldn't crawl (rejecting):", u.String(), err)
 				default:
 					item.Reject(false)
 					log.Warningln("Couldn't crawl (rejecting):", u.String(), err)
@@ -266,7 +256,7 @@ func PublishURLs(ttlHashSet *ttl_hash_set.TTLHashSet, queueManager *queue.Manage
 
 		u := uu.String()
 
-		if(uu.RawQuery != "") {
+		if uu.RawQuery != "" {
 			values, err := url.ParseQuery(uu.RawQuery)
 			if err != nil {
 				log.Debugln("Skipping URL unable to decode query params:", u)


### PR DESCRIPTION
This commit adds the functionality for the crawler to follow redirects when it receives a HTTP 301, 302, 303 or 307 status code for a crawled URL.

A synthetic HTML response with a meta redirect tag is returned, which prompts the crawler to create a file containing this HTML (allowing redirects to work when serving statically) and also adds the destination URL to the list of URLs to be crawled (allowing the content at the eventual destination to be saved).