### PR TITLE
Change javascript mime from x-javascript to javascript

### DIFF
--- a/http_crawler/crawler_response.go
+++ b/http_crawler/crawler_response.go
@@ -14,7 +14,7 @@ const (
 	HTML       = "text/html"
 	ICO        = "image/x-icon"
 	ICS        = "text/calendar"
-	JAVASCRIPT = "application/x-javascript"
+	JAVASCRIPT = "application/javascript"
 	JPEG       = "image/jpeg"
 	JSON       = "application/json"
 	ODP        = "application/vnd.oasis.opendocument.presentation"


### PR DESCRIPTION
The crawler seems to be missing some js file, this is testing a
theory that this could be due to wrong mime type.