### PR TITLE
Replace deprecated deployIntegration function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ node {
       }
 
       stage("Deploy") {
-        govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER, 'deploy')
+        govuk.deployToIntegration(REPOSITORY, 'release_' + env.BUILD_NUMBER, 'deploy')
       }
     }
 


### PR DESCRIPTION
Trello: https://trello.com/c/amnaU0V9/853-decommission-the-publishing-end-to-end-tests

As per: https://github.com/alphagov/govuk-jenkinslib/commit/99e8541c7a44c7cfebff0da171b3643573ad869b