### PR TITLE
Reduce default number of retries to 1

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 	crawlerThreads    = util.GetEnvDefault("CRAWLER_THREADS", "4")
 	exchangeName      = util.GetEnvDefault("AMQP_EXCHANGE", "govuk_crawler_exchange")
 	httpPort          = util.GetEnvDefault("HTTP_PORT", "8080")
-	maxCrawlRetries   = util.GetEnvDefault("MAX_CRAWL_RETRIES", "4")
+	maxCrawlRetries   = util.GetEnvDefault("MAX_CRAWL_RETRIES", "1")
 	queueName         = util.GetEnvDefault("AMQP_MESSAGE_QUEUE", "govuk_crawler_queue")
 	redisAddr         = util.GetEnvDefault("REDIS_ADDRESS", "127.0.0.1:6379")
 	redisKeyPrefix    = util.GetEnvDefault("REDIS_KEY_PREFIX", "gcw")
@@ -133,7 +133,7 @@ func main() {
 	var maxCrawlRetriesInt int
 	maxCrawlRetriesInt, err = strconv.Atoi(maxCrawlRetries)
 	if err != nil {
-		maxCrawlRetriesInt = 4
+		maxCrawlRetriesInt = 1
 	}
 
 	crawlChan = ReadFromQueue(deliveries, rootURLs, ttlHashSet, splitPaths(blacklistPaths), crawlerThreadsInt)


### PR DESCRIPTION
[Trello card](https://trello.com/c/uqQza0Ss/3267-reduce-the-number-of-times-the-crawler-will-attempt-to-fetch-a-path-if-origin-is-erroring)

If origin responds with a 500 on the first try and the first retry, it's unlikely that it will start responding with a 200 on any of the 2nd-4th retries.

Retrying 4 times means we send 4x more issues to Sentry than necessary, which creates extra noise and counts against our quota.

Although this is configurable via an environment variable, we don't currently use this functionality (either in Puppet or anywhere else across alphagov).